### PR TITLE
Error handling

### DIFF
--- a/lib/dry/files.rb
+++ b/lib/dry/files.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module Dry
+  # File manipulations
+  #
+  # @since 0.1.0
+  # @api public
   class Files
     require_relative "files/version"
     require_relative "files/error"
@@ -10,9 +14,10 @@ module Dry
     #
     # @param adapter [Dry::FileSystem]
     #
-    # @return [Dry::Files]
+    # @return [Dry::Files] a new files instance
     #
-    # @since x.x.x
+    # @since 0.1.0
+    # @api public
     def initialize(memory: false, adapter: Adapter.call(memory: memory))
       @adapter = adapter
     end
@@ -23,12 +28,27 @@ module Dry
     #
     # @param path [String,Pathname] the path to file
     #
-    # @since x.x.x
+    # @raise [Dry::Files::IOError] in case of I/O error
+    #
+    # @since 0.1.0
+    # @api public
     def touch(path)
       mkdir_p(path)
       adapter.touch(path)
     end
 
+    # Read file content
+    #
+    # @param path [String,Pathname] the path to file
+    #
+    # @return [String] the file contents
+    #
+    # @raise [Dry::Files::IOError] in case of I/O error
+    #
+    # @since 0.1.0
+    # @api public
+    #
+    # TODO: allow buffered read
     def read(path)
       adapter.read(path)
     end
@@ -40,7 +60,10 @@ module Dry
     # @param path [String,Pathname] the path to file
     # @param content [String, Array<String>] the content to write
     #
-    # @since x.x.x
+    # @raise [Dry::Files::IOError] in case of I/O error
+    #
+    # @since 0.1.0
+    # @api public
     def write(path, *content)
       mkdir_p(path)
       open(path, WRITE_MODE, *content) # rubocop:disable Security/Open - this isn't a call to `::Kernel.open`, but to `self.open`
@@ -53,7 +76,10 @@ module Dry
     # @param source [String,Pathname] the path to the source file
     # @param destination [String,Pathname] the path to the destination file
     #
-    # @since x.x.x
+    # @raise [Dry::Files::IOError] in case of I/O error
+    #
+    # @since 0.1.0
+    # @api public
     def cp(source, destination)
       mkdir_p(destination)
       adapter.cp(source, destination)
@@ -66,7 +92,8 @@ module Dry
     #
     # @return [String] the joined path
     #
-    # @since x.x.x
+    # @since 0.1.0
+    # @api public
     def join(*path)
       adapter.join(*path)
     end
@@ -81,7 +108,7 @@ module Dry
     #
     # @return [String] the expanded path
     #
-    # @since x.x.x
+    # @since 0.1.0
     def expand_path(path, dir = pwd)
       adapter.expand_path(path, dir)
     end
@@ -90,7 +117,7 @@ module Dry
     #
     # @return [String] the current working directory.
     #
-    # @since x.x.x
+    # @since 0.1.0
     def pwd
       adapter.pwd
     end
@@ -101,7 +128,7 @@ module Dry
     # @param path [String,Pathname] the target directory
     # @param blk [Proc] the code to execute with the target directory
     #
-    # @since x.x.x
+    # @since 0.1.0
     def chdir(path, &blk)
       adapter.chdir(path, &blk)
     end
@@ -112,7 +139,10 @@ module Dry
     #
     # @param path [String,Pathname] the path to directory
     #
-    # @since x.x.x
+    # @raise [Dry::Files::IOError] in case of I/O error
+    #
+    # @since 0.1.0
+    # @api public
     #
     # @see #mkdir_p
     #
@@ -136,7 +166,10 @@ module Dry
     #
     # @param path [String,Pathname] the path to directory
     #
-    # @since x.x.x
+    # @raise [Dry::Files::IOError] in case of I/O error
+    #
+    # @since 0.1.0
+    # @api public
     #
     # @see #mkdir
     #
@@ -157,9 +190,10 @@ module Dry
     #
     # @param path [String,Pathname] the path to file
     #
-    # @raise [Errno::ENOENT] if the path doesn't exist
+    # @raise [Dry::Files::IOError] in case of I/O error
     #
-    # @since x.x.x
+    # @since 0.1.0
+    # @api public
     def delete(path)
       adapter.rm(path)
     end
@@ -168,9 +202,10 @@ module Dry
     #
     # @param path [String,Pathname] the path to file
     #
-    # @raise [Errno::ENOENT] if the path doesn't exist
+    # @raise [Dry::Files::IOError] in case of I/O error
     #
-    # @since x.x.x
+    # @since 0.1.0
+    # @api public
     def delete_directory(path)
       adapter.rm_rf(path)
     end
@@ -180,11 +215,12 @@ module Dry
     # @param path [String,Pathname] the path to file
     # @param line [String] the line to add
     #
-    # @raise [Errno::ENOENT] if the path doesn't exist
+    # @raise [Dry::Files::IOError] in case of I/O error
     #
     # @see #append
     #
-    # @since x.x.x
+    # @since 0.1.0
+    # @api public
     def unshift(path, line)
       content = adapter.readlines(path)
       content.unshift(newline(line))
@@ -197,11 +233,12 @@ module Dry
     # @param path [String,Pathname] the path to file
     # @param contents [String] the contents to add
     #
-    # @raise [Errno::ENOENT] if the path doesn't exist
+    # @raise [Dry::Files::IOError] in case of I/O error
     #
     # @see #unshift
     #
-    # @since x.x.x
+    # @since 0.1.0
+    # @api public
     def append(path, contents)
       mkdir_p(path)
 
@@ -218,12 +255,13 @@ module Dry
     # @param target [String,Regexp] the target to replace
     # @param replacement [String] the replacement
     #
-    # @raise [Errno::ENOENT] if the path doesn't exist
-    # @raise [ArgumentError] if `target` cannot be found in `path`
+    # @raise [Dry::Files::IOError] in case of I/O error
+    # @raise [Dry::Files::MissingTargetError] if `target` cannot be found in `path`
     #
     # @see #replace_last_line
     #
-    # @since x.x.x
+    # @since 0.1.0
+    # @api public
     def replace_first_line(path, target, replacement)
       content = adapter.readlines(path)
       content[index(content, path, target)] = newline(replacement)
@@ -237,12 +275,13 @@ module Dry
     # @param target [String,Regexp] the target to replace
     # @param replacement [String] the replacement
     #
-    # @raise [Errno::ENOENT] if the path doesn't exist
-    # @raise [ArgumentError] if `target` cannot be found in `path`
+    # @raise [Dry::Files::IOError] in case of I/O error
+    # @raise [Dry::Files::MissingTargetError] if `target` cannot be found in `path`
     #
     # @see #replace_first_line
     #
-    # @since x.x.x
+    # @since 0.1.0
+    # @api public
     def replace_last_line(path, target, replacement)
       content = adapter.readlines(path)
       content[-index(content.reverse, path, target) - CONTENT_OFFSET] = newline(replacement)
@@ -256,14 +295,15 @@ module Dry
     # @param target [String,Regexp] the target to replace
     # @param contents [String] the contents to inject
     #
-    # @raise [Errno::ENOENT] if the path doesn't exist
-    # @raise [ArgumentError] if `target` cannot be found in `path`
+    # @raise [Dry::Files::IOError] in case of I/O error
+    # @raise [Dry::Files::MissingTargetError] if `target` cannot be found in `path`
     #
     # @see #inject_line_after
     # @see #inject_line_before_last
     # @see #inject_line_after_last
     #
-    # @since x.x.x
+    # @since 0.1.0
+    # @api public
     def inject_line_before(path, target, contents)
       _inject_line_before(path, target, contents, method(:index))
     end
@@ -274,14 +314,15 @@ module Dry
     # @param target [String,Regexp] the target to replace
     # @param contents [String] the contents to inject
     #
-    # @raise [Errno::ENOENT] if the path doesn't exist
-    # @raise [ArgumentError] if `target` cannot be found in `path`
+    # @raise [Dry::Files::IOError] in case of I/O error
+    # @raise [Dry::Files::MissingTargetError] if `target` cannot be found in `path`
     #
     # @see #inject_line_before
     # @see #inject_line_after
     # @see #inject_line_after_last
     #
-    # @since x.x.x
+    # @since 0.1.0
+    # @api public
     def inject_line_before_last(path, target, contents)
       _inject_line_before(path, target, contents, method(:rindex))
     end
@@ -292,14 +333,15 @@ module Dry
     # @param target [String,Regexp] the target to replace
     # @param contents [String] the contents to inject
     #
-    # @raise [Errno::ENOENT] if the path doesn't exist
-    # @raise [ArgumentError] if `target` cannot be found in `path`
+    # @raise [Dry::Files::IOError] in case of I/O error
+    # @raise [Dry::Files::MissingTargetError] if `target` cannot be found in `path`
     #
     # @see #inject_line_before
     # @see #inject_line_before_last
     # @see #inject_line_after_last
     #
-    # @since x.x.x
+    # @since 0.1.0
+    # @api public
     def inject_line_after(path, target, contents)
       _inject_line_after(path, target, contents, method(:index))
     end
@@ -310,14 +352,15 @@ module Dry
     # @param target [String,Regexp] the target to replace
     # @param contents [String] the contents to inject
     #
-    # @raise [Errno::ENOENT] if the path doesn't exist
-    # @raise [ArgumentError] if `target` cannot be found in `path`
+    # @raise [Dry::Files::IOError] in case of I/O error
+    # @raise [Dry::Files::MissingTargetError] if `target` cannot be found in `path`
     #
     # @see #inject_line_before
     # @see #inject_line_after
     # @see #inject_line_before_last
     #
-    # @since x.x.x
+    # @since 0.1.0
+    # @api public
     def inject_line_after_last(path, target, contents)
       _inject_line_after(path, target, contents, method(:rindex))
     end
@@ -329,10 +372,11 @@ module Dry
     # @param target [String,Regexp] the target matcher for Ruby block
     # @param contents [String,Array<String>] the contents to inject
     #
-    # @raise [Errno::ENOENT] if the path doesn't exist
-    # @raise [ArgumentError] if `target` cannot be found in `path`
+    # @raise [Dry::Files::IOError] in case of I/O error
+    # @raise [Dry::Files::MissingTargetError] if `target` cannot be found in `path`
     #
-    # @since x.x.x
+    # @since 0.1.0
+    # @api public
     #
     # @example Inject a single line
     #   require "dry/files"
@@ -446,10 +490,11 @@ module Dry
     # @param target [String,Regexp] the target matcher for Ruby block
     # @param contents [String,Array<String>] the contents to inject
     #
-    # @raise [Errno::ENOENT] if the path doesn't exist
-    # @raise [ArgumentError] if `target` cannot be found in `path`
+    # @raise [Dry::Files::IOError] in case of I/O error
+    # @raise [Dry::Files::MissingTargetError] if `target` cannot be found in `path`
     #
-    # @since x.x.x
+    # @since 0.1.0
+    # @api public
     #
     # @example Inject a single line
     #   require "dry/files"
@@ -566,10 +611,11 @@ module Dry
     # @param path [String,Pathname] the path to file
     # @param target [String,Regexp] the target to remove
     #
-    # @raise [Errno::ENOENT] if the path doesn't exist
-    # @raise [ArgumentError] if `target` cannot be found in `path`
+    # @raise [Dry::Files::IOError] in case of I/O error
+    # @raise [Dry::Files::MissingTargetError] if `target` cannot be found in `path`
     #
-    # @since x.x.x
+    # @since 0.1.0
+    # @api public
     def remove_line(path, target)
       content = adapter.readlines(path)
       i       = index(content, path, target)
@@ -583,10 +629,11 @@ module Dry
     # @param path [String,Pathname] the path to file
     # @param target [String] the target block to remove
     #
-    # @raise [Errno::ENOENT] if the path doesn't exist
-    # @raise [ArgumentError] if `target` cannot be found in `path`
+    # @raise [Dry::Files::IOError] in case of I/O error
+    # @raise [Dry::Files::MissingTargetError] if `target` cannot be found in `path`
     #
-    # @since x.x.x
+    # @since 0.1.0
+    # @api public
     #
     # @example
     #   require "dry/files"
@@ -626,7 +673,8 @@ module Dry
     #
     # @return [TrueClass,FalseClass] the result of the check
     #
-    # @since x.x.x
+    # @since 0.1.0
+    # @api public
     #
     # @example
     #   require "dry/files"
@@ -645,7 +693,8 @@ module Dry
     #
     # @return [TrueClass,FalseClass] the result of the check
     #
-    # @since x.x.x
+    # @since 0.1.0
+    # @api public
     #
     # @example
     #   require "dry/files"
@@ -664,7 +713,8 @@ module Dry
     #
     # @return [TrueClass,FalseClass] the result of the check
     #
-    # @since x.x.x
+    # @since 0.1.0
+    # @api public
     #
     # @example
     #   require "dry/files"
@@ -679,74 +729,74 @@ module Dry
 
     private
 
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     NEW_LINE = $/ # rubocop:disable Style/SpecialGlobalVars
     private_constant :NEW_LINE
 
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     WRITE_MODE = (::File::CREAT | ::File::WRONLY | ::File::TRUNC).freeze
     private_constant :WRITE_MODE
 
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     CONTENT_OFFSET = 1
     private_constant :CONTENT_OFFSET
 
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     SPACE = " "
     private_constant :SPACE
 
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     INDENTATION = 2
     private_constant :INDENTATION
 
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     SPACE_MATCHER = /\A[[:space:]]*/.freeze
     private_constant :SPACE_MATCHER
 
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     INLINE_OPEN_BLOCK_MATCHER = "{"
     private_constant :INLINE_OPEN_BLOCK_MATCHER
 
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     INLINE_CLOSE_BLOCK = "}"
     private_constant :INLINE_CLOSE_BLOCK
 
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     CLOSE_BLOCK = "end"
     private_constant :CLOSE_BLOCK
 
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     attr_reader :adapter
 
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     def newline(line = nil)
       "#{line}#{NEW_LINE}"
     end
 
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     def newline?(content)
       content.end_with?(NEW_LINE)
     end
 
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     def match?(content, target)
       !line_number(content, target).nil?
     end
 
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     def open(path, mode, *content)
       adapter.open(path, mode) do |f|
@@ -754,21 +804,21 @@ module Dry
       end
     end
 
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     def index(content, path, target)
-      line_number(content, target) ||
-        raise(ArgumentError, "Cannot find `#{target}' inside `#{path}'.")
+      line_number(content, target) or
+        raise MissingTargetError.new(target, path)
     end
 
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     def rindex(content, path, target)
-      line_number(content, target, finder: content.method(:rindex)) ||
-        raise(ArgumentError, "Cannot find `#{target}' inside `#{path}'.")
+      line_number(content, target, finder: content.method(:rindex)) or
+        raise MissingTargetError.new(target, path)
     end
 
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     def _inject_line_before(path, target, contents, finder)
       content = adapter.readlines(path)
@@ -778,7 +828,7 @@ module Dry
       write(path, content)
     end
 
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     def _inject_line_after(path, target, contents, finder)
       content = adapter.readlines(path)
@@ -788,7 +838,7 @@ module Dry
       write(path, content)
     end
 
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     def _offset_block_lines(contents, offset)
       contents.map do |line|
@@ -801,7 +851,7 @@ module Dry
       end.join
     end
 
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     def line_number(content, target, finder: content.method(:index))
       finder.call do |l|

--- a/lib/dry/files.rb
+++ b/lib/dry/files.rb
@@ -128,6 +128,8 @@ module Dry
     # @param path [String,Pathname] the target directory
     # @param blk [Proc] the code to execute with the target directory
     #
+    # @raise [Dry::Files::IOError] in case of I/O error
+    #
     # @since 0.1.0
     def chdir(path, &blk)
       adapter.chdir(path, &blk)

--- a/lib/dry/files/error.rb
+++ b/lib/dry/files/error.rb
@@ -2,7 +2,83 @@
 
 module Dry
   class Files
+    # Dry::Files base error
+    #
+    # @since 0.1.0
+    # @api public
     class Error < StandardError
+    end
+
+    # Wraps low level I/O errors
+    #
+    # @see https://ruby-doc.org/core/Errno.html
+    #
+    # @since 0.1.0
+    # @api public
+    class IOError < Error
+      # Instantiate a new `Dry::Files::IOError`
+      #
+      # @param cause [Exception] the low level exception
+      #
+      # @return [Dry::Files::IOError] the new error
+      #
+      # @since 0.1.0
+      # @api private
+      def initialize(cause)
+        super(cause.message)
+        @_cause = cause
+      end
+
+      # The original exception
+      #
+      # @see https://ruby-doc.org/core/Exception.html#method-i-cause
+      #
+      # @since 0.1.0
+      # @api public
+      def cause
+        @_cause
+      end
+    end
+
+    # File manipulations error.
+    # Raised when the given `target` cannot be found in `path`.
+    #
+    # @since 0.1.0
+    # @api public
+    class MissingTargetError < Error
+      # @param target [String,Regexp] the missing target
+      # @param path [String,Pathname] the file
+      #
+      # @return [Dry::Files::MissingTargetError] the new error
+      #
+      # @since 0.1.0
+      # @api private
+      def initialize(target, path)
+        super("Cannot find `#{target}' in `#{path}'")
+
+        @_target = target
+        @_path = path
+      end
+
+      # The missing target
+      #
+      # @return [String, Regexp] the missing target
+      #
+      # @since 0.1.0
+      # @api public
+      def target
+        @_target
+      end
+
+      # The missing target
+      #
+      # @return [String,Pathname] the file
+      #
+      # @since 0.1.0
+      # @api public
+      def path
+        @_path
+      end
     end
   end
 end

--- a/lib/dry/files/file_system.rb
+++ b/lib/dry/files/file_system.rb
@@ -39,8 +39,7 @@ module Dry
       #
       # @param path [String, Array<String>] the target path
       #
-      # @raise [Dry::Files::Error] if path is an existing directory
-      # @raise [Dry::Files::Error] in case of I/O error
+      # @raise [Dry::Files::IOError] in case of I/O error
       #
       # @since x.x.x
       # @api private
@@ -61,7 +60,7 @@ module Dry
       #
       # @param path [String, Array<String>] the target path
       #
-      # @raise [Dry::Files::Error] in case of I/O error
+      # @raise [Dry::Files::IOError] in case of I/O error
       #
       # @since x.x.x
       # @api private
@@ -77,6 +76,8 @@ module Dry
       #
       # @param path [String] the target file
       #
+      # @raise [Dry::Files::IOError] in case of I/O error
+      #
       # @since x.x.x
       # @api private
       def open(path, *args, &blk)
@@ -91,6 +92,8 @@ module Dry
       #
       # @param source [String] the file(s) or directory to copy
       # @param destination [String] the directory destination
+      #
+      # @raise [Dry::Files::IOError] in case of I/O error
       #
       # @since x.x.x
       # @api private
@@ -148,10 +151,14 @@ module Dry
       # @param path [String,Pathname] the target directory
       # @param blk [Proc] the code to execute with the target directory
       #
+      # @raise [Dry::Files::IOError] in case of I/O error
+      #
       # @since x.x.x
       # @api private
       def chdir(path, &blk)
-        file_utils.chdir(path, &blk)
+        with_error_handling do
+          file_utils.chdir(path, &blk)
+        end
       end
 
       # Creates a directory and all its parent directories.
@@ -163,6 +170,8 @@ module Dry
       # @see https://ruby-doc.org/stdlib/libdoc/fileutils/rdoc/FileUtils.html#method-c-mkdir_p
       #
       # @param path [String] the directory to create
+      #
+      # @raise [Dry::Files::IOError] in case of I/O error
       #
       # @example
       #   require "dry/cli/utils/files/file_system"
@@ -189,6 +198,9 @@ module Dry
       #
       # @param path [String] the file that will be in the directories that
       #                      this method creates
+      #
+      # @raise [Dry::Files::IOError] in case of I/O error
+      #
       # @example
       #   require "dry/cli/utils/files/file_system"
       #
@@ -211,6 +223,8 @@ module Dry
       #
       # @param path [String] the file to remove
       #
+      # @raise [Dry::Files::IOError] in case of I/O error
+      #
       # @since x.x.x
       # @api private
       def rm(path, **kwargs)
@@ -224,6 +238,8 @@ module Dry
       # @see https://ruby-doc.org/stdlib/libdoc/fileutils/rdoc/FileUtils.html#method-c-remove_entry_secure
       #
       # @param path [String] the directory to remove
+      #
+      # @raise [Dry::Files::IOError] in case of I/O error
       #
       # @since x.x.x
       # @api private
@@ -239,6 +255,8 @@ module Dry
       # @see https://ruby-doc.org/core/IO.html#method-c-readlines
       #
       # @param path [String] the file to read
+      #
+      # @raise [Dry::Files::IOError] in case of I/O error
       #
       # @since x.x.x
       # @api private
@@ -286,6 +304,16 @@ module Dry
 
       private
 
+      # Catch `SystemCallError` and re-raise a `Dry::Files::IOError`.
+      #
+      # `SystemCallError` is parent for all the `Errno::*` Ruby exceptions.
+      # These class of exceptions are raised in case of I/O error.
+      #
+      # @see https://ruby-doc.org/core/SystemCallError.html
+      # @see https://ruby-doc.org/core/Errno.html
+      #
+      # @raise [Dry::Files::IOError] in case of I/O error
+      #
       # @since x.x.x
       # @api private
       def with_error_handling

--- a/spec/integration/dry/files_spec.rb
+++ b/spec/integration/dry/files_spec.rb
@@ -36,6 +36,47 @@ RSpec.describe Dry::Files do
       expect(path).to exist
       expect(path).to have_content("foo")
     end
+
+    it "raises error if path is a directory" do
+      path = root.join("touch-directory")
+      path.mkpath
+
+      expect { subject.touch(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::EISDIR)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+  end
+
+  describe "#read" do
+    it "reads file" do
+      path = root.join("read")
+      subject.write(path, expected = "Hello#{newline}World")
+
+      expect(subject.read(path)).to eq(expected)
+    end
+
+    it "raises error when path is a directory" do
+      path = root.join("read-directory")
+      path.mkpath
+
+      expect { subject.read(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::EISDIR)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+
+    it "raises error when path doesn't exist" do
+      path = root.join("read-does-not-exist")
+
+      expect { subject.read(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
   end
 
   describe "#write" do
@@ -62,6 +103,24 @@ RSpec.describe Dry::Files do
 
       expect(path).to exist
       expect(path).to have_content("new words")
+    end
+
+    it "raises error when path isn't writeable" do
+      path = root.join("write-not-writeable")
+      path.mkpath
+      mode = path.stat.mode
+
+      begin
+        path.chmod(0o000)
+
+        expect { subject.write(path.join("file-not-writeable"), "content") }.to raise_error do |exception|
+          expect(exception).to be_kind_of(Dry::Files::IOError)
+          expect(exception.cause).to be_kind_of(Errno::EACCES)
+          expect(exception.message).to include(path.to_s)
+        end
+      ensure
+        path.chmod(mode)
+      end
     end
   end
 
@@ -104,6 +163,29 @@ RSpec.describe Dry::Files do
       expect(destination).to exist
       expect(destination).to have_content("the source")
     end
+
+    it "raises error when source cannot be found" do
+      source = root.join("missing-source")
+      destination = root.join("cp")
+
+      expect { subject.cp(source, destination) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to match("No such file or directory")
+      end
+    end
+  end
+
+  describe "#join" do
+  end
+
+  describe "#expand_path" do
+  end
+
+  describe "#pwd" do
+  end
+
+  describe "#chdir" do
   end
 
   describe "#mkdir" do
@@ -119,6 +201,24 @@ RSpec.describe Dry::Files do
       subject.mkdir(path)
 
       expect(path).to be_directory
+    end
+
+    it "raises error when path isn't writeable" do
+      path = root.join("mkdir-not-writeable")
+      path.mkpath
+      mode = path.stat.mode
+
+      begin
+        path.chmod(0o000)
+
+        expect { subject.mkdir(path.join("dir-not-writeable")) }.to raise_error do |exception|
+          expect(exception).to be_kind_of(Dry::Files::IOError)
+          expect(exception.cause).to be_kind_of(Errno::EACCES)
+          expect(exception.message).to include(path.to_s)
+        end
+      ensure
+        path.chmod(mode)
+      end
     end
   end
 
@@ -140,6 +240,25 @@ RSpec.describe Dry::Files do
       expect(directory).to be_directory
       expect(path).to_not  exist
     end
+
+    it "raises error when path isn't writeable" do
+      parent = root.join("path")
+      parent.mkpath
+      mode = parent.stat.mode
+
+      begin
+        parent.chmod(0o000)
+        path = parent.join("to", "mkdir_p", "dir-not-writeable")
+
+        expect { subject.mkdir_p(path) }.to raise_error do |exception|
+          expect(exception).to be_kind_of(Dry::Files::IOError)
+          expect(exception.cause).to be_kind_of(Errno::EACCES)
+          expect(exception.message).to include(parent.to_s)
+        end
+      ensure
+        parent.chmod(mode)
+      end
+    end
   end
 
   describe "#delete" do
@@ -155,11 +274,10 @@ RSpec.describe Dry::Files do
       path = root.join("delete", "file")
 
       expect { subject.delete(path) }.to raise_error do |exception|
-        expect(exception).to be_kind_of(Errno::ENOENT)
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
         expect(exception.message).to match("No such file or directory")
       end
-
-      expect(path).to_not exist
     end
   end
 
@@ -176,11 +294,10 @@ RSpec.describe Dry::Files do
       path = root.join("delete", "directory")
 
       expect { subject.delete_directory(path) }.to raise_error do |exception|
-        expect(exception).to be_kind_of(Errno::ENOENT)
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
         expect(exception.message).to match("No such file or directory")
       end
-
-      expect(path).to_not exist
     end
   end
 
@@ -221,8 +338,9 @@ RSpec.describe Dry::Files do
       path = root.join("unshift_no_exist.rb")
 
       expect { subject.unshift(path, "# frozen_string_literal: true") }.to raise_error do |exception|
-        expect(exception).to be_kind_of(Errno::ENOENT)
-        expect(exception.message).to match("No such file or directory")
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
       end
 
       expect(path).to_not exist
@@ -250,6 +368,9 @@ RSpec.describe Dry::Files do
       expect(path).to have_content(expected)
     end
 
+    # This gem was originally extracted from hanami-utils, into dry-cli,
+    # and finally into dry-files.
+    #
     # https://github.com/hanami/utils/issues/348
     it "adds a line at the bottom of a file that doesn't end with a newline" do
       path = root.join("append_missing_newline.rb")
@@ -270,8 +391,9 @@ RSpec.describe Dry::Files do
       path = root.join("append_no_exist.rb")
 
       expect { subject.append(path, "#{newline} Foo.register Append") }.to raise_error do |exception|
-        expect(exception).to be_kind_of(Errno::ENOENT)
-        expect(exception.message).to match("No such file or directory")
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
       end
 
       expect(path).to_not exist
@@ -363,8 +485,8 @@ RSpec.describe Dry::Files do
       subject.write(path, content)
 
       expect { subject.replace_first_line(path, "not existing target", "  def self.call(input)") }.to raise_error do |exception|
-        expect(exception).to be_kind_of(ArgumentError)
-        expect(exception.message).to eq("Cannot find `not existing target' inside `#{path}'.")
+        expect(exception).to be_kind_of(Dry::Files::MissingTargetError)
+        expect(exception.message).to eq("Cannot find `not existing target' in `#{path}'")
       end
 
       expect(path).to have_content(content)
@@ -374,8 +496,9 @@ RSpec.describe Dry::Files do
       path = root.join("replace_no_exist.rb")
 
       expect { subject.replace_first_line(path, "perform", "  def self.call(input)") }.to raise_error do |exception|
-        expect(exception).to be_kind_of(Errno::ENOENT)
-        expect(exception.message).to match("No such file or directory")
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
       end
 
       expect(path).to_not exist
@@ -467,8 +590,8 @@ RSpec.describe Dry::Files do
       subject.write(path, content)
 
       expect { subject.replace_last_line(path, "not existing target", "  def self.call(input)") }.to raise_error do |exception|
-        expect(exception).to be_kind_of(ArgumentError)
-        expect(exception.message).to eq("Cannot find `not existing target' inside `#{path}'.")
+        expect(exception).to be_kind_of(Dry::Files::MissingTargetError)
+        expect(exception.message).to eq("Cannot find `not existing target' in `#{path}'")
       end
 
       expect(path).to have_content(content)
@@ -478,8 +601,9 @@ RSpec.describe Dry::Files do
       path = root.join("replace_last_no_exist.rb")
 
       expect { subject.replace_last_line(path, "perform", "  def self.call(input)") }.to raise_error do |exception|
-        expect(exception).to be_kind_of(Errno::ENOENT)
-        expect(exception.message).to match("No such file or directory")
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
       end
 
       expect(path).to_not exist
@@ -545,8 +669,8 @@ RSpec.describe Dry::Files do
       subject.write(path, content)
 
       expect { subject.inject_line_before(path, "not existing target", "  # It performs the operation") }.to raise_error do |exception|
-        expect(exception).to be_kind_of(ArgumentError)
-        expect(exception.message).to eq("Cannot find `not existing target' inside `#{path}'.")
+        expect(exception).to be_kind_of(Dry::Files::MissingTargetError)
+        expect(exception.message).to eq("Cannot find `not existing target' in `#{path}'")
       end
 
       expect(path).to have_content(content)
@@ -556,8 +680,9 @@ RSpec.describe Dry::Files do
       path = root.join("inject_before_no_exist.rb")
 
       expect { subject.inject_line_before(path, "call", "  # It performs the operation") }.to raise_error do |exception|
-        expect(exception).to be_kind_of(Errno::ENOENT)
-        expect(exception.message).to match("No such file or directory")
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
       end
 
       expect(path).to_not exist
@@ -633,8 +758,8 @@ RSpec.describe Dry::Files do
       subject.write(path, content)
 
       expect { subject.inject_line_before_last(path, "not existing target", "  # It performs the operation") }.to raise_error do |exception|
-        expect(exception).to be_kind_of(ArgumentError)
-        expect(exception.message).to eq("Cannot find `not existing target' inside `#{path}'.")
+        expect(exception).to be_kind_of(Dry::Files::MissingTargetError)
+        expect(exception.message).to eq("Cannot find `not existing target' in `#{path}'")
       end
 
       expect(path).to have_content(content)
@@ -644,8 +769,9 @@ RSpec.describe Dry::Files do
       path = root.join("inject_before_last_no_exist.rb")
 
       expect { subject.inject_line_before_last(path, "call", "  # It performs the operation") }.to raise_error do |exception|
-        expect(exception).to be_kind_of(Errno::ENOENT)
-        expect(exception.message).to match("No such file or directory")
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
       end
 
       expect(path).to_not exist
@@ -711,8 +837,8 @@ RSpec.describe Dry::Files do
       subject.write(path, content)
 
       expect { subject.inject_line_after(path, "not existing target", "    :result") }.to raise_error do |exception|
-        expect(exception).to be_kind_of(ArgumentError)
-        expect(exception.message).to eq("Cannot find `not existing target' inside `#{path}'.")
+        expect(exception).to be_kind_of(Dry::Files::MissingTargetError)
+        expect(exception.message).to eq("Cannot find `not existing target' in `#{path}'")
       end
 
       expect(path).to have_content(content)
@@ -722,8 +848,9 @@ RSpec.describe Dry::Files do
       path = root.join("inject_after_no_exist.rb")
 
       expect { subject.inject_line_after(path, "call", "    :result") }.to raise_error do |exception|
-        expect(exception).to be_kind_of(Errno::ENOENT)
-        expect(exception.message).to match("No such file or directory")
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
       end
 
       expect(path).to_not exist
@@ -799,8 +926,8 @@ RSpec.describe Dry::Files do
       subject.write(path, content)
 
       expect { subject.inject_line_after_last(path, "not existing target", "    :result") }.to raise_error do |exception|
-        expect(exception).to be_kind_of(ArgumentError)
-        expect(exception.message).to eq("Cannot find `not existing target' inside `#{path}'.")
+        expect(exception).to be_kind_of(Dry::Files::MissingTargetError)
+        expect(exception.message).to eq("Cannot find `not existing target' in `#{path}'")
       end
 
       expect(path).to have_content(content)
@@ -810,8 +937,9 @@ RSpec.describe Dry::Files do
       path = root.join("inject_after_last_no_exist.rb")
 
       expect { subject.inject_line_after_last(path, "call", "    :result") }.to raise_error do |exception|
-        expect(exception).to be_kind_of(Errno::ENOENT)
-        expect(exception.message).to match("No such file or directory")
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
       end
 
       expect(path).to_not exist
@@ -878,8 +1006,8 @@ RSpec.describe Dry::Files do
       subject.write(path, content)
 
       expect { subject.remove_line(path, "not existing target") }.to raise_error do |exception|
-        expect(exception).to be_kind_of(ArgumentError)
-        expect(exception.message).to eq("Cannot find `not existing target' inside `#{path}'.")
+        expect(exception).to be_kind_of(Dry::Files::MissingTargetError)
+        expect(exception.message).to eq("Cannot find `not existing target' in `#{path}'")
       end
 
       expect(path).to have_content(content)
@@ -889,8 +1017,9 @@ RSpec.describe Dry::Files do
       path = root.join("remove_line_no_exist.rb")
 
       expect { subject.remove_line(path, "frozen") }.to raise_error do |exception|
-        expect(exception).to be_kind_of(Errno::ENOENT)
-        expect(exception.message).to match("No such file or directory")
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
       end
 
       expect(path).to_not exist
@@ -1010,9 +1139,11 @@ RSpec.describe Dry::Files do
     it "raises error if file cannot be found" do
       path = root.join("inject_line_at_block_top_missing_file.rb")
 
-      expect {
-        subject.inject_line_at_block_top(path, "configure", "")
-      }.to raise_error(Errno::ENOENT)
+      expect { subject.inject_line_at_block_top(path, "configure", "") }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
+      end
     end
 
     it "raises error if Ruby block cannot be found" do
@@ -1025,9 +1156,10 @@ RSpec.describe Dry::Files do
 
       subject.write(path, content)
 
-      expect {
-        subject.inject_line_at_block_top(path, "configure", "")
-      }.to raise_error(ArgumentError, "Cannot find `configure' inside `#{path.realpath}'.")
+      expect { subject.inject_line_at_block_top(path, "configure", "") }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::MissingTargetError)
+        expect(exception.message).to eq("Cannot find `configure' in `#{path.realpath}'")
+      end
     end
   end
 
@@ -1144,9 +1276,11 @@ RSpec.describe Dry::Files do
     it "raises error if file cannot be found" do
       path = root.join("inject_line_at_block_bottom_missing_file.rb")
 
-      expect {
-        subject.inject_line_at_block_bottom(path, "configure", "")
-      }.to raise_error(Errno::ENOENT)
+      expect { subject.inject_line_at_block_bottom(path, "configure", "") }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
+      end
     end
 
     it "raises error if Ruby block cannot be found" do
@@ -1159,9 +1293,10 @@ RSpec.describe Dry::Files do
 
       subject.write(path, content)
 
-      expect {
-        subject.inject_line_at_block_top(path, "configure", "")
-      }.to raise_error(ArgumentError, "Cannot find `configure' inside `#{path.realpath}'.")
+      expect { subject.inject_line_at_block_top(path, "configure", "") }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::MissingTargetError)
+        expect(exception.message).to eq("Cannot find `configure' in `#{path.realpath}'")
+      end
     end
   end
 
@@ -1218,24 +1353,14 @@ RSpec.describe Dry::Files do
       expect(path).to have_content(expected)
     end
 
-    it "raises error if block cannot be found in path" do
+    it "raises an error when the file was not found" do
       path = root.join("remove_block_not_found.rb")
-      content = <<~CONTENT
-        class RemoveBlock
-          configure do
-            root __dir__
-          end
-        end
-      CONTENT
 
-      subject.write(path, content)
-
-      expect { subject.remove_block(path, "not existing target") }.to raise_error do |exception|
-        expect(exception).to be_kind_of(ArgumentError)
-        expect(exception.message).to eq("Cannot find `not existing target' inside `#{path}'.")
+      expect { subject.remove_block(path, "configure") }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
       end
-
-      expect(path).to have_content(content)
     end
 
     it "raises error if block cannot be found" do
@@ -1251,40 +1376,31 @@ RSpec.describe Dry::Files do
       subject.write(path, content)
 
       expect { subject.remove_block(path, "not existing target") }.to raise_error do |exception|
-        expect(exception).to be_kind_of(ArgumentError)
-        expect(exception.message).to eq("Cannot find `not existing target' inside `#{path}'.")
+        expect(exception).to be_kind_of(Dry::Files::MissingTargetError)
+        expect(exception.message).to eq("Cannot find `not existing target' in `#{path}'")
       end
 
       expect(path).to have_content(content)
-    end
-
-    it "raises an error when the file was not found" do
-      path = root.join("remove_block_not_found.rb")
-
-      expect { subject.remove_block(path, "configure") }.to raise_error do |exception|
-        expect(exception).to be_kind_of(Errno::ENOENT)
-        expect(exception.message).to match("No such file or directory")
-      end
     end
   end
 
   describe "#exist?" do
     it "returns true for file" do
-      path = root.join("exist_file")
+      path = root.join("exist-file")
       subject.touch(path)
 
       expect(subject.exist?(path)).to be(true)
     end
 
     it "returns true for directory" do
-      path = root.join("exist_directory")
+      path = root.join("exist-dir")
       subject.mkdir(path)
 
       expect(subject.exist?(path)).to be(true)
     end
 
     it "returns false for non-existing file" do
-      path = root.join("exist_not_found")
+      path = root.join("exist-non-existing")
 
       expect(subject.exist?(path)).to be(false)
     end
@@ -1292,23 +1408,53 @@ RSpec.describe Dry::Files do
 
   describe "#directory?" do
     it "returns true for directory" do
-      path = root.join("directory_directory")
+      path = root.join("directory-dir")
       subject.mkdir(path)
 
       expect(subject.exist?(path)).to be(true)
     end
 
     it "returns false for file" do
-      path = root.join("directory_file")
+      path = root.join("directory-file")
       subject.touch(path)
 
       expect(subject.directory?(path)).to be(false)
     end
 
     it "returns false for non-existing path" do
-      path = root.join("directory_not_found")
+      path = root.join("directory-non-existing")
 
-      expect(subject.exist?(path)).to be(false)
+      expect(subject.directory?(path)).to be(false)
+    end
+  end
+
+  describe "#executable?" do
+    it "returns true when file is executable" do
+      path = root.join("executable-exec")
+      subject.touch(path)
+      path.chmod(0o744)
+
+      expect(subject.executable?(path)).to be(true)
+    end
+
+    it "returns false when file isn't executable" do
+      path = root.join("executable-non-exec")
+      subject.touch(path)
+
+      expect(subject.executable?(path)).to be(false)
+    end
+
+    it "returns false when file doesn't exist" do
+      path = root.join("executable-non-existing")
+
+      expect(subject.executable?(path)).to be(false)
+    end
+
+    it "returns true for directory" do
+      path = root.join("executable-directory")
+      subject.mkdir(path)
+
+      expect(subject.executable?(path)).to be(true)
     end
   end
 end


### PR DESCRIPTION
## Enhancement

### I/O Errors

Wrap low level I/O errors into `Dry::Files::IOError`.

The class of exceptions that is caught is `SystemCallError`.
This is a superclass for all the `Errno::*` exceptions that Ruby raises in case of I/O error. For instance, when a file isn't found, Ruby raises Errno::ENOENT

Example:

```ruby
# frozen_string_literal: true

require "dry/files"

files = Dry::Files.new

begin
  files.read("non-existing-file")
rescue Dry::Files::Error => exception
  exception.class # => Dry::Files::IOError
  exception.cause # => Errno::ENOENT
  exception.message # => "No such file or directory @ rb_sysopen - non-existing-file"
end
```

Note that `exception.message` is the original message of `Errno::ENOENT`.

### Target matching errors

When manipulating file contents, if there isn't a match for the given `target`, the code used to raise a generic `ArgumentError`.
In order to make life easier for end users, I introduced `Dry::Files::MissingTargetError`.

The reason is that end users can catch a generic `Dry::Files::Error`, which is parent for all the exceptions that the code raises.


Example:

```ruby
# frozen_string_literal: true

require "dry/files"

files = Dry::Files.new

begin
  path = "/path/to/file"
  files.inject_line_after(path, "configure", "some content to inject")
rescue Dry::Files::Error => exception
  exception.class # => Dry::Files::MissingTargetError
  exception.message # => "Cannot find `configure' in `/path/to/file'"
end
```