### PR TITLE
Adapters

### DIFF
--- a/lib/dry/files.rb
+++ b/lib/dry/files.rb
@@ -100,7 +100,7 @@ module Dry
     # Relative paths are referenced from the current working directory of
     # the process unless `dir` is given.
     #
-    # @param source [String,Pathname] the path to the file
+    # @param path [String,Pathname] the path to the file
     # @param dir [String,Pathname] the base directory
     #
     # @return [String] the expanded path

--- a/lib/dry/files.rb
+++ b/lib/dry/files.rb
@@ -12,6 +12,9 @@ module Dry
 
     # Creates a new instance
     #
+    # Memory file system is experimental
+    #
+    # @param memory [TrueClass,FalseClass] use in-memory, ephemeral file system
     # @param adapter [Dry::FileSystem]
     #
     # @return [Dry::Files] a new files instance
@@ -20,20 +23,6 @@ module Dry
     # @api public
     def initialize(memory: false, adapter: Adapter.call(memory: memory))
       @adapter = adapter
-    end
-
-    # Creates an empty file for the given path.
-    # All the intermediate directories are created.
-    # If the path already exists, it doesn't change the contents
-    #
-    # @param path [String,Pathname] the path to file
-    #
-    # @raise [Dry::Files::IOError] in case of I/O error
-    #
-    # @since 0.1.0
-    # @api public
-    def touch(path)
-      adapter.touch(path)
     end
 
     # Read file content
@@ -52,6 +41,20 @@ module Dry
       adapter.read(path)
     end
 
+    # Creates an empty file for the given path.
+    # All the intermediate directories are created.
+    # If the path already exists, it doesn't change the contents
+    #
+    # @param path [String,Pathname] the path to file
+    #
+    # @raise [Dry::Files::IOError] in case of I/O error
+    #
+    # @since 0.1.0
+    # @api public
+    def touch(path)
+      adapter.touch(path)
+    end
+
     # Creates a new file or rewrites the contents
     # of an existing file for the given path and content
     # All the intermediate directories are created.
@@ -65,21 +68,6 @@ module Dry
     # @api public
     def write(path, *content)
       adapter.write(path, *content)
-    end
-
-    # Copies source into destination.
-    # All the intermediate directories are created.
-    # If the destination already exists, it overrides the contents.
-    #
-    # @param source [String,Pathname] the path to the source file
-    # @param destination [String,Pathname] the path to the destination file
-    #
-    # @raise [Dry::Files::IOError] in case of I/O error
-    #
-    # @since 0.1.0
-    # @api public
-    def cp(source, destination)
-      adapter.cp(source, destination)
     end
 
     # Returns a new string formed by joining the strings using Operating
@@ -183,6 +171,21 @@ module Dry
     #     # => creates the `path/to` directory
     def mkdir_p(path)
       adapter.mkdir_p(path)
+    end
+
+    # Copies source into destination.
+    # All the intermediate directories are created.
+    # If the destination already exists, it overrides the contents.
+    #
+    # @param source [String,Pathname] the path to the source file
+    # @param destination [String,Pathname] the path to the destination file
+    #
+    # @raise [Dry::Files::IOError] in case of I/O error
+    #
+    # @since 0.1.0
+    # @api public
+    def cp(source, destination)
+      adapter.cp(source, destination)
     end
 
     # Deletes given path (file).

--- a/lib/dry/files.rb
+++ b/lib/dry/files.rb
@@ -64,8 +64,7 @@ module Dry
     # @since 0.1.0
     # @api public
     def write(path, *content)
-      mkdir_p(path)
-      open(path, WRITE_MODE, *content) # rubocop:disable Security/Open - this isn't a call to `::Kernel.open`, but to `self.open`
+      adapter.write(path, *content)
     end
 
     # Copies source into destination.
@@ -734,11 +733,6 @@ module Dry
     # @api private
     NEW_LINE = $/ # rubocop:disable Style/SpecialGlobalVars
     private_constant :NEW_LINE
-
-    # @since 0.1.0
-    # @api private
-    WRITE_MODE = (::File::CREAT | ::File::WRONLY | ::File::TRUNC).freeze
-    private_constant :WRITE_MODE
 
     # @since 0.1.0
     # @api private

--- a/lib/dry/files.rb
+++ b/lib/dry/files.rb
@@ -79,7 +79,6 @@ module Dry
     # @since 0.1.0
     # @api public
     def cp(source, destination)
-      mkdir_p(destination)
       adapter.cp(source, destination)
     end
 

--- a/lib/dry/files.rb
+++ b/lib/dry/files.rb
@@ -33,7 +33,6 @@ module Dry
     # @since 0.1.0
     # @api public
     def touch(path)
-      mkdir_p(path)
       adapter.touch(path)
     end
 

--- a/lib/dry/files.rb
+++ b/lib/dry/files.rb
@@ -209,6 +209,66 @@ module Dry
       adapter.rm_rf(path)
     end
 
+    # Checks if `path` exist
+    #
+    # @param path [String,Pathname] the path to file
+    #
+    # @return [TrueClass,FalseClass] the result of the check
+    #
+    # @since 0.1.0
+    # @api public
+    #
+    # @example
+    #   require "dry/files"
+    #
+    #   Dry::Files.new.exist?(__FILE__) # => true
+    #   Dry::Files.new.exist?(__dir__)  # => true
+    #
+    #   Dry::Files.new.exist?("missing_file") # => false
+    def exist?(path)
+      adapter.exist?(path)
+    end
+
+    # Checks if `path` is a directory
+    #
+    # @param path [String,Pathname] the path to directory
+    #
+    # @return [TrueClass,FalseClass] the result of the check
+    #
+    # @since 0.1.0
+    # @api public
+    #
+    # @example
+    #   require "dry/files"
+    #
+    #   Dry::Files.new.directory?(__dir__)  # => true
+    #   Dry::Files.new.directory?(__FILE__) # => false
+    #
+    #   Dry::Files.new.directory?("missing_directory") # => false
+    def directory?(path)
+      adapter.directory?(path)
+    end
+
+    # Checks if `path` is an executable
+    #
+    # @param path [String,Pathname] the path to file
+    #
+    # @return [TrueClass,FalseClass] the result of the check
+    #
+    # @since 0.1.0
+    # @api public
+    #
+    # @example
+    #   require "dry/files"
+    #
+    #   Dry::Files.new.executable?("/path/to/ruby") # => true
+    #   Dry::Files.new.executable?(__FILE__)        # => false
+    #
+    #   Dry::Files.new.directory?("missing_file") # => false
+    def executable?(path)
+      adapter.executable?(path)
+    end
+
     # Adds a new line at the top of the file
     #
     # @param path [String,Pathname] the path to file
@@ -666,66 +726,6 @@ module Dry
       remove_block(path, target) if match?(content, target)
     end
 
-    # Checks if `path` exist
-    #
-    # @param path [String,Pathname] the path to file
-    #
-    # @return [TrueClass,FalseClass] the result of the check
-    #
-    # @since 0.1.0
-    # @api public
-    #
-    # @example
-    #   require "dry/files"
-    #
-    #   Dry::Files.new.exist?(__FILE__) # => true
-    #   Dry::Files.new.exist?(__dir__)  # => true
-    #
-    #   Dry::Files.new.exist?("missing_file") # => false
-    def exist?(path)
-      adapter.exist?(path)
-    end
-
-    # Checks if `path` is a directory
-    #
-    # @param path [String,Pathname] the path to directory
-    #
-    # @return [TrueClass,FalseClass] the result of the check
-    #
-    # @since 0.1.0
-    # @api public
-    #
-    # @example
-    #   require "dry/files"
-    #
-    #   Dry::Files.new.directory?(__dir__)  # => true
-    #   Dry::Files.new.directory?(__FILE__) # => false
-    #
-    #   Dry::Files.new.directory?("missing_directory") # => false
-    def directory?(path)
-      adapter.directory?(path)
-    end
-
-    # Checks if `path` is an executable
-    #
-    # @param path [String,Pathname] the path to file
-    #
-    # @return [TrueClass,FalseClass] the result of the check
-    #
-    # @since 0.1.0
-    # @api public
-    #
-    # @example
-    #   require "dry/files"
-    #
-    #   Dry::Files.new.executable?("/path/to/ruby") # => true
-    #   Dry::Files.new.executable?(__FILE__)        # => false
-    #
-    #   Dry::Files.new.directory?("missing_file") # => false
-    def executable?(path)
-      adapter.executable?(path)
-    end
-
     private
 
     # @since 0.1.0
@@ -788,14 +788,6 @@ module Dry
     # @api private
     def match?(content, target)
       !line_number(content, target).nil?
-    end
-
-    # @since 0.1.0
-    # @api private
-    def open(path, mode, *content)
-      adapter.open(path, mode) do |f|
-        f.write(Array(content).flatten.join)
-      end
     end
 
     # @since 0.1.0

--- a/lib/dry/files/adapter.rb
+++ b/lib/dry/files/adapter.rb
@@ -2,10 +2,10 @@
 
 module Dry
   class Files
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     class Adapter
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def self.call(memory:)
         if memory

--- a/lib/dry/files/error.rb
+++ b/lib/dry/files/error.rb
@@ -87,7 +87,7 @@ module Dry
     #
     # @since 0.1.0
     # @api public
-    class UnknownMemoryNode < Error
+    class UnknownMemoryNodeError < Error
       # Instantiate a new error
       #
       # @param node [String] node name
@@ -96,6 +96,24 @@ module Dry
       # @api public
       def initialize(node)
         super("unknown memory node `#{node}'")
+      end
+    end
+
+    # Not a memory file
+    #
+    # Raised by the memory adapter (used for testing purposes)
+    #
+    # @since 0.1.0
+    # @api public
+    class NotMemoryFileError < Error
+      # Instantiate a new error
+      #
+      # @param path [String] path name
+      #
+      # @since 0.1.0
+      # @api public
+      def initialize(path)
+        super("not a memory file `#{path}'")
       end
     end
   end

--- a/lib/dry/files/error.rb
+++ b/lib/dry/files/error.rb
@@ -54,7 +54,7 @@ module Dry
       # @since 0.1.0
       # @api private
       def initialize(target, path)
-        super("Cannot find `#{target}' in `#{path}'")
+        super("cannot find `#{target}' in `#{path}'")
 
         @_target = target
         @_path = path
@@ -78,6 +78,24 @@ module Dry
       # @api public
       def path
         @_path
+      end
+    end
+
+    # Unknown memory node
+    #
+    # Raised by the memory adapter (used for testing purposes)
+    #
+    # @since 0.1.0
+    # @api public
+    class UnknownMemoryNode < Error
+      # Instantiate a new error
+      #
+      # @param node [String] node name
+      #
+      # @since 0.1.0
+      # @api public
+      def initialize(node)
+        super("unknown memory node `#{node}'")
       end
     end
   end

--- a/lib/dry/files/file_system.rb
+++ b/lib/dry/files/file_system.rb
@@ -107,6 +107,8 @@ module Dry
       # @since x.x.x
       # @api private
       def cp(source, destination, **kwargs)
+        mkdir_p(destination)
+
         with_error_handling do
           file_utils.cp(source, destination, **kwargs)
         end

--- a/lib/dry/files/file_system.rb
+++ b/lib/dry/files/file_system.rb
@@ -71,6 +71,14 @@ module Dry
         end
       end
 
+      def write(path, *content)
+        mkdir_p(path)
+
+        self.open(path, WRITE_MODE) do |f|
+          f.write(Array(content).flatten.join)
+        end
+      end
+
       # Opens (or creates) a new file for read/write operations.
       #
       # @see https://ruby-doc.org/core/File.html#method-c-open
@@ -304,6 +312,11 @@ module Dry
       end
 
       private
+
+      # @since 0.1.0
+      # @api private
+      WRITE_MODE = (::File::CREAT | ::File::WRONLY | ::File::TRUNC).freeze
+      private_constant :WRITE_MODE
 
       # Catch `SystemCallError` and re-raise a `Dry::Files::IOError`.
       #

--- a/lib/dry/files/file_system.rb
+++ b/lib/dry/files/file_system.rb
@@ -6,14 +6,14 @@ module Dry
   class Files
     # File System abstraction to support `Dry::Files`
     #
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     class FileSystem
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       attr_reader :file
 
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       attr_reader :file_utils
 
@@ -24,25 +24,33 @@ module Dry
       #
       # @return [Dry::Files::FileSystem]
       #
-      # @since x.x.x
+      # @since 0.1.0
       def initialize(file: File, file_utils: FileUtils)
         @file = file
         @file_utils = file_utils
       end
 
-      # Opens (or creates) a new file for read/write operations.
+      # Opens (or creates) a new file for both read/write operations.
+      #
+      # If the file doesn't exist, it creates a new one.
       #
       # @see https://ruby-doc.org/core/File.html#method-c-open
       #
       # @param path [String] the target file
+      # @param mode [String,Integer] Ruby file open mode
+      # @param args [Array<Object>] ::File.open args
+      # @param blk [Proc] the block to yield
+      #
+      # @yieldparam [::File] the opened file
       #
       # @raise [Dry::Files::IOError] in case of I/O error
       #
-      # @since x.x.x
-      # @api private
-      def open(path, *args, &blk)
+      # @since 0.1.0
+      def open(path, mode = OPEN_MODE, *args, &blk)
+        touch(path)
+
         with_error_handling do
-          file.open(path, *args, &blk)
+          file.open(path, mode, *args, &blk)
         end
       end
 
@@ -57,7 +65,7 @@ module Dry
       #
       # @raise [Dry::Files::IOError] in case of I/O error
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def read(path, *args, **kwargs)
         with_error_handling do
@@ -74,7 +82,7 @@ module Dry
       #
       # @raise [Dry::Files::IOError] in case of I/O error
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def readlines(path, *args)
         with_error_handling do
@@ -93,7 +101,7 @@ module Dry
       #
       # @raise [Dry::Files::IOError] in case of I/O error
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def touch(path, **kwargs)
         raise IOError, Errno::EISDIR.new(path.to_s) if directory?(path)
@@ -132,7 +140,7 @@ module Dry
       #
       # @return [String] the joined path
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def join(*path)
         file.join(*path)
@@ -145,7 +153,7 @@ module Dry
       # @param path [String,Pathname] the path to the file
       # @param dir [String,Pathname] the base directory
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def expand_path(path, dir)
         file.expand_path(path, dir)
@@ -157,7 +165,7 @@ module Dry
       #
       # @return [String] the current working directory.
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def pwd
         file_utils.pwd
@@ -175,7 +183,7 @@ module Dry
       #
       # @raise [Dry::Files::IOError] in case of I/O error
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def chdir(path, &blk)
         with_error_handling do
@@ -202,7 +210,7 @@ module Dry
       #   fs.mkdir("/usr/var/project")
       #   # creates all the directory structure (/usr/var/project)
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def mkdir(path, **kwargs)
         with_error_handling do
@@ -231,7 +239,7 @@ module Dry
       #   # creates all the directory structure (/usr/var/project)
       #   # where file.rb will eventually live
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def mkdir_p(path, **kwargs)
         mkdir(
@@ -249,7 +257,7 @@ module Dry
       #
       # @raise [Dry::Files::IOError] in case of I/O error
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def cp(source, destination, **kwargs)
         mkdir_p(destination)
@@ -269,7 +277,7 @@ module Dry
       #
       # @raise [Dry::Files::IOError] in case of I/O error
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def rm(path, **kwargs)
         with_error_handling do
@@ -285,7 +293,7 @@ module Dry
       #
       # @raise [Dry::Files::IOError] in case of I/O error
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def rm_rf(path, *args)
         with_error_handling do
@@ -301,7 +309,7 @@ module Dry
       #
       # @return [TrueClass,FalseClass] the result of the check
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def exist?(path)
         file.exist?(path)
@@ -315,7 +323,7 @@ module Dry
       #
       # @return [TrueClass,FalseClass] the result of the check
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def directory?(path)
         file.directory?(path)
@@ -329,13 +337,18 @@ module Dry
       #
       # @return [TrueClass,FalseClass] the result of the check
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def executable?(path)
         file.executable?(path)
       end
 
       private
+
+      # @since 0.1.0
+      # @api private
+      OPEN_MODE = ::File::RDWR
+      private_constant :OPEN_MODE
 
       # @since 0.1.0
       # @api private
@@ -352,7 +365,7 @@ module Dry
       #
       # @raise [Dry::Files::IOError] in case of I/O error
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def with_error_handling
         yield

--- a/lib/dry/files/file_system.rb
+++ b/lib/dry/files/file_system.rb
@@ -47,6 +47,7 @@ module Dry
         raise IOError, Errno::EISDIR.new(path.to_s) if directory?(path)
 
         with_error_handling do
+          mkdir_p(path)
           file_utils.touch(path, **kwargs)
         end
       end

--- a/lib/dry/files/file_system.rb
+++ b/lib/dry/files/file_system.rb
@@ -71,6 +71,17 @@ module Dry
         end
       end
 
+      # Creates a new file or rewrites the contents
+      # of an existing file for the given path and content
+      # All the intermediate directories are created.
+      #
+      # @param path [String,Pathname] the path to file
+      # @param content [String, Array<String>] the content to write
+      #
+      # @raise [Dry::Files::IOError] in case of I/O error
+      #
+      # @since 0.1.0
+      # @api private
       def write(path, *content)
         mkdir_p(path)
 

--- a/lib/dry/files/memory_file_system.rb
+++ b/lib/dry/files/memory_file_system.rb
@@ -220,14 +220,12 @@ module Dry
         path = Path[path]
 
         mkdir(
-          ::File.dirname(path)
+          Path.dirname(path)
         )
       end
 
       # Copies file content from `source` to `destination`
       # All the intermediate `destination` directories are created.
-      #
-      # @see https://ruby-doc.org/stdlib/libdoc/fileutils/rdoc/FileUtils.html#method-c-cp
       #
       # @param source [String,Array<String>] the file(s) or directory to copy
       # @param destination [String,Array<String>] the directory destination

--- a/lib/dry/files/memory_file_system.rb
+++ b/lib/dry/files/memory_file_system.rb
@@ -6,9 +6,14 @@ module Dry
   class Files
     # Memory File System abstraction to support `Dry::Files`
     #
-    # @since x.x.x
+    # @since 0.1.0
     # @api private
     class MemoryFileSystem
+      # @since 0.1.0
+      # @api private
+      EMPTY_CONTENT = nil
+      private_constant :EMPTY_CONTENT
+
       require_relative "./memory_file_system/node"
 
       # Creates a new instance
@@ -18,7 +23,7 @@ module Dry
       #
       # @return [Dry::Files::MemoryFileSystem]
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def initialize(root: Node.root)
         @root = root
@@ -29,10 +34,10 @@ module Dry
       # @param path [String] the target file
       # @yiedparam [Dry::Files::MemoryFileSystem::Node]
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def open(path, *, &blk)
-        file = write(path, EMPTY_CONTENT)
+        file = touch(path)
         blk.call(file)
       end
 
@@ -44,7 +49,7 @@ module Dry
       # @raise [Dry::Files::IOError] in case the target path is a directory or
       #   if the file cannot be found
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def read(path)
         path = Path[path]
@@ -65,7 +70,7 @@ module Dry
       # @raise [Dry::Files::IOError] in case the target path is a directory or
       #   if the file cannot be found
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def readlines(path)
         path = Path[path]
@@ -85,7 +90,7 @@ module Dry
       #
       # @raise [Dry::Files::IOError] in case the target path is a directory
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def touch(path)
         path = Path[path]
@@ -123,7 +128,7 @@ module Dry
       #
       # @return [String] the joined path
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def join(*path)
         Path[path]
@@ -134,7 +139,7 @@ module Dry
       # @param path [String,Array<String>] the path to the file
       # @param dir [String,Array<String>] the base directory
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def expand_path(path, dir)
         return path if Path.absolute?(path)
@@ -146,7 +151,7 @@ module Dry
       #
       # @return [String] the current working directory.
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def pwd
         @root.segment
@@ -163,7 +168,7 @@ module Dry
       # @raise [Dry::Files::IOError] if path cannot be found or it isn't a
       #   directory
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def chdir(path, &blk)
         path = Path[path]
@@ -190,7 +195,7 @@ module Dry
       #
       # @raise [Dry::Files::IOError] in case path is an already existing file
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def mkdir(path)
         path = Path[path]
@@ -214,7 +219,7 @@ module Dry
       #
       # @raise [Dry::Files::IOError] in case of I/O error
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def mkdir_p(path)
         path = Path[path]
@@ -232,7 +237,7 @@ module Dry
       #
       # @raise [Dry::Files::IOError] if source cannot be found
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def cp(source, destination)
         content = read(source)
@@ -247,7 +252,7 @@ module Dry
       #
       # @see #rm_rf
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def rm(path)
         path = Path[path]
@@ -277,7 +282,7 @@ module Dry
       #
       # @see #rm
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def rm_rf(path)
         path = Path[path]
@@ -298,17 +303,14 @@ module Dry
         parent.unset(file)
       end
 
-      EMPTY_CONTENT = nil
-      private_constant :EMPTY_CONTENT
-
-      # Changes node UNIX mode
+      # Sets node UNIX mode
       #
       # @param path [String,Array<String>] the path to the node
       # @param mode [Integer] a UNIX mode, in base 2, 8, 10, or 16
       #
       # @raise [Dry::Files::IOError] if path cannot be found
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def chmod(path, mode)
         path = Path[path]
@@ -319,12 +321,30 @@ module Dry
         node.chmod = mode
       end
 
+      # Gets node UNIX mode
+      #
+      # @param path [String,Array<String>] the path to the node
+      # @return [Integer] the UNIX mode
+      #
+      # @raise [Dry::Files::IOError] if path cannot be found
+      #
+      # @since 0.1.0
+      # @api private
+      def mode(path)
+        path = Path[path]
+        node = find(path)
+
+        raise IOError, Errno::ENOENT.new(path.to_s) if node.nil?
+
+        node.mode
+      end
+
       # Check if the given path exist.
       #
       # @param path [String,Array<String>] the path to the node
       # @return [TrueClass,FalseClass] the result of the check
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def exist?(path)
         path = Path[path]
@@ -337,7 +357,7 @@ module Dry
       # @param path [String,Array<String>] the path to the directory
       # @return [TrueClass,FalseClass] the result of the check
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def directory?(path)
         path = Path[path]
@@ -349,7 +369,7 @@ module Dry
       # @param path [String,Array<String>] the path to the node
       # @return [TrueClass,FalseClass] the result of the check
       #
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def executable?(path)
         path = Path[path]
@@ -362,14 +382,14 @@ module Dry
 
       private
 
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def for_each_segment(path, &blk)
         segments = Path.split(path)
         segments.each(&blk)
       end
 
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def find_directory(path)
         node = find(path)
@@ -380,7 +400,7 @@ module Dry
         node
       end
 
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def find_file(path)
         node = find(path)
@@ -391,7 +411,7 @@ module Dry
         node
       end
 
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       def find(path)
         node = @root

--- a/lib/dry/files/memory_file_system.rb
+++ b/lib/dry/files/memory_file_system.rb
@@ -11,10 +11,82 @@ module Dry
     class MemoryFileSystem
       require_relative "./memory_file_system/node"
 
+      # Creates a new instance
+      #
+      # @param root [Dry::Files::MemoryFileSystem::Node] the root node of the
+      #   in-memory file system
+      #
+      # @return [Dry::Files::MemoryFileSystem]
+      #
+      # @since x.x.x
+      # @api private
       def initialize(root: Node.root)
         @root = root
       end
 
+      # Opens (or creates) a new file for read/write operations.
+      #
+      # @param path [String] the target file
+      # @yiedparam [Dry::Files::MemoryFileSystem::Node]
+      #
+      # @since x.x.x
+      # @api private
+      def open(path, *, &blk)
+        file = write(path, EMPTY_CONTENT)
+        blk.call(file)
+      end
+
+      # Read file contents
+      #
+      # @param path [String, Array<String>] the target path
+      # @return [String] the file contents
+      #
+      # @raise [Dry::Files::IOError] in case the target path is a directory or
+      #   if the file cannot be found
+      #
+      # @since x.x.x
+      # @api private
+      def read(path)
+        path = Path[path]
+        raise IOError, Errno::EISDIR.new(path.to_s) if directory?(path)
+
+        file = find_file(path)
+        raise IOError, Errno::ENOENT.new(path.to_s) if file.nil?
+
+        file.read
+      end
+
+      # Reads the entire file specified by path as individual lines,
+      # and returns those lines in an array
+      #
+      # @param path [String, Array<String>] the target path
+      # @return [Array<String>] the file contents
+      #
+      # @raise [Dry::Files::IOError] in case the target path is a directory or
+      #   if the file cannot be found
+      #
+      # @since x.x.x
+      # @api private
+      def readlines(path)
+        path = Path[path]
+        node = find(path)
+
+        raise IOError, Errno::ENOENT.new(path.to_s) if node.nil?
+        raise IOError, Errno::EISDIR.new(path.to_s) if node.directory?
+
+        node.readlines
+      end
+
+      # Creates a file, if it doesn't exist, and set empty content.
+      #
+      # If the file was already existing, it's a no-op.
+      #
+      # @param path [String, Array<String>] the target path
+      #
+      # @raise [Dry::Files::IOError] in case the target path is a directory
+      #
+      # @since x.x.x
+      # @api private
       def touch(path)
         path = Path[path]
         raise IOError, Errno::EISDIR.new(path.to_s) if directory?(path)
@@ -23,19 +95,162 @@ module Dry
         write(path, content || EMPTY_CONTENT)
       end
 
+      # Creates a new file or rewrites the contents
+      # of an existing file for the given path and content
+      # All the intermediate directories are created.
+      #
+      # @param path [String, Array<String>] the target path
+      # @param content [String, Array<String>] the content to write
+      #
+      # @since 0.1.0
+      # @api private
+      def write(path, *content)
+        path = Path[path]
+        node = @root
+
+        for_each_segment(path) do |segment|
+          node = node.set(segment)
+        end
+
+        node.write(*content)
+        node
+      end
+
+      # Returns a new string formed by joining the strings using Operating
+      # System path separator
+      #
+      # @param path [String,Array<String>] path tokens
+      #
+      # @return [String] the joined path
+      #
+      # @since x.x.x
+      # @api private
       def join(*path)
         Path[path]
       end
 
+      # Converts a path to an absolute path.
+      #
+      # @param path [String,Array<String>] the path to the file
+      # @param dir [String,Array<String>] the base directory
+      #
+      # @since x.x.x
+      # @api private
+      def expand_path(path, dir)
+        return path if path.start_with?(::File::SEPARATOR)
+
+        join(dir, path)
+      end
+
+      # Returns the name of the current working directory.
+      #
+      # @return [String] the current working directory.
+      #
+      # @since x.x.x
+      # @api private
       def pwd
         @root.segment
       end
 
+      # Temporary changes the current working directory of the process to the
+      # given path and yield the given block.
+      #
+      # The argument `path` is intended to be a **directory**.
+      #
+      # @param path [String] the target directory
+      # @param blk [Proc] the code to execute with the target directory
+      #
+      # @raise [Dry::Files::IOError] if path cannot be found or it isn't a
+      #   directory
+      #
+      # @since x.x.x
+      # @api private
+      def chdir(path, &blk)
+        path = Path[path]
+        directory = find(path)
+
+        raise IOError, Errno::ENOENT.new(path.to_s) if directory.nil?
+        raise IOError, Errno::ENOTDIR.new(path.to_s) unless directory.directory?
+
+        current_root = @root
+        @root = directory
+        blk.call
+      ensure
+        @root = current_root
+      end
+
+      # Creates a directory and all its parent directories.
+      #
+      # The argument `path` is intended to be a **directory** that you want to
+      # explicitly create.
+      #
+      # @see #mkdir_p
+      #
+      # @param path [String,Array<String>] the directory to create
+      #
+      # @raise [Dry::Files::IOError] in case path is an already existing file
+      #
+      # @since x.x.x
+      # @api private
+      def mkdir(path)
+        path = Path[path]
+        node = @root
+
+        for_each_segment(path) do |segment|
+          node = node.set(segment)
+          raise IOError, Errno::EEXIST.new(path.to_s) if node.file?
+        end
+      end
+
+      # Creates a directory and all its parent directories.
+      #
+      # The argument `path` is intended to be a **file**, where its
+      # directory ancestors will be implicitly created.
+      #
+      # @see #mkdir
+      #
+      # @param path [String,Array<String>] the file that will be in the
+      #   directories that this method creates
+      #
+      # @raise [Dry::Files::IOError] in case of I/O error
+      #
+      # @since x.x.x
+      # @api private
+      def mkdir_p(path)
+        path = Path[path]
+
+        mkdir(
+          ::File.dirname(path)
+        )
+      end
+
+      # Copies file content from `source` to `destination`
+      # All the intermediate `destination` directories are created.
+      #
+      # @see https://ruby-doc.org/stdlib/libdoc/fileutils/rdoc/FileUtils.html#method-c-cp
+      #
+      # @param source [String,Array<String>] the file(s) or directory to copy
+      # @param destination [String,Array<String>] the directory destination
+      #
+      # @raise [Dry::Files::IOError] if source cannot be found
+      #
+      # @since x.x.x
+      # @api private
       def cp(source, destination)
         content = read(source)
         write(destination, content)
       end
 
+      # Removes (deletes) a file
+      #
+      # @param path [String,Array<String>] the file to remove
+      #
+      # @raise [Dry::Files::IOError] if path cannot be found or it's a directory
+      #
+      # @see #rm_rf
+      #
+      # @since x.x.x
+      # @api private
       def rm(path)
         path = Path[path]
         file = nil
@@ -56,6 +271,16 @@ module Dry
         parent.unset(file)
       end
 
+      # Removes (deletes) a directory
+      #
+      # @param path [String,Array<String>] the directory to remove
+      #
+      # @raise [Dry::Files::IOError] if path cannot be found
+      #
+      # @see #rm
+      #
+      # @since x.x.x
+      # @api private
       def rm_rf(path)
         path = Path[path]
         file = nil
@@ -75,67 +300,18 @@ module Dry
         parent.unset(file)
       end
 
-      def chdir(path)
-        path = Path[path]
-        directory = find(path)
-
-        raise IOError, Errno::ENOENT.new(path.to_s) if directory.nil?
-        raise IOError, Errno::ENOTDIR.new(path.to_s) unless directory.directory?
-
-        current_root = @root
-        @root = directory
-        yield
-      ensure
-        @root = current_root
-      end
-
-      def mkdir(path)
-        path = Path[path]
-        node = @root
-
-        for_each_segment(path) do |segment|
-          node = node.set(segment)
-        end
-      end
-
-      def mkdir_p(path)
-        path = Path[path]
-
-        mkdir(
-          ::File.dirname(path)
-        )
-      end
-
       EMPTY_CONTENT = nil
       private_constant :EMPTY_CONTENT
 
-      def open(path, *, &blk)
-        file = write(path, EMPTY_CONTENT)
-        blk.call(file)
-      end
-
-      def read(path)
-        path = Path[path]
-        raise IOError, Errno::EISDIR.new(path.to_s) if directory?(path)
-
-        file = find_file(path)
-        raise IOError, Errno::ENOENT.new(path.to_s) if file.nil?
-
-        file.read
-      end
-
-      def write(path, *content)
-        path = Path[path]
-        node = @root
-
-        for_each_segment(path) do |segment|
-          node = node.set(segment)
-        end
-
-        node.write(*content)
-        node
-      end
-
+      # Changes node UNIX mode
+      #
+      # @param path [String,Array<String>] the path to the node
+      # @param mode [Integer] a UNIX mode, in base 2, 8, 10, or 16
+      #
+      # @raise [Dry::Files::IOError] if path cannot be found
+      #
+      # @since x.x.x
+      # @api private
       def chmod(path, mode)
         path = Path[path]
         node = find(path)
@@ -145,27 +321,38 @@ module Dry
         node.chmod = mode
       end
 
-      def readlines(path)
-        path = Path[path]
-        node = find(path)
-
-        raise IOError, Errno::ENOENT.new(path.to_s) if node.nil?
-        raise IOError, Errno::EISDIR.new(path.to_s) if node.directory?
-
-        node.readlines
-      end
-
+      # Check if the given path exist.
+      #
+      # @param path [String,Array<String>] the path to the node
+      # @return [TrueClass,FalseClass] the result of the check
+      #
+      # @since x.x.x
+      # @api private
       def exist?(path)
         path = Path[path]
 
         !find(path).nil?
       end
 
+      # Check if the given path corresponds to a directory.
+      #
+      # @param path [String,Array<String>] the path to the directory
+      # @return [TrueClass,FalseClass] the result of the check
+      #
+      # @since x.x.x
+      # @api private
       def directory?(path)
         path = Path[path]
         !find_directory(path).nil?
       end
 
+      # Check if the given path is an executable.
+      #
+      # @param path [String,Array<String>] the path to the node
+      # @return [TrueClass,FalseClass] the result of the check
+      #
+      # @since x.x.x
+      # @api private
       def executable?(path)
         path = Path[path]
 
@@ -177,11 +364,15 @@ module Dry
 
       private
 
+      # @since x.x.x
+      # @api private
       def for_each_segment(path, &blk)
         segments = Path.split(path)
         segments.each(&blk)
       end
 
+      # @since x.x.x
+      # @api private
       def find_directory(path)
         node = find(path)
 
@@ -191,6 +382,8 @@ module Dry
         node
       end
 
+      # @since x.x.x
+      # @api private
       def find_file(path)
         node = find(path)
 
@@ -200,6 +393,8 @@ module Dry
         node
       end
 
+      # @since x.x.x
+      # @api private
       def find(path)
         node = @root
 

--- a/lib/dry/files/memory_file_system.rb
+++ b/lib/dry/files/memory_file_system.rb
@@ -137,7 +137,7 @@ module Dry
       # @since x.x.x
       # @api private
       def expand_path(path, dir)
-        return path if path.start_with?(::File::SEPARATOR)
+        return path if Path.absolute?(path)
 
         join(dir, path)
       end

--- a/lib/dry/files/memory_file_system.rb
+++ b/lib/dry/files/memory_file_system.rb
@@ -94,7 +94,7 @@ module Dry
         node = @root
 
         for_each_segment(path) do |segment|
-          node = node.put(segment)
+          node = node.set(segment)
         end
       end
 
@@ -129,7 +129,7 @@ module Dry
         node = @root
 
         for_each_segment(path) do |segment|
-          node = node.put(segment)
+          node = node.set(segment)
         end
 
         node.file!(*content)

--- a/lib/dry/files/memory_file_system.rb
+++ b/lib/dry/files/memory_file_system.rb
@@ -136,6 +136,15 @@ module Dry
         node
       end
 
+      def chmod(path, mode)
+        path = Path[path]
+        node = find(path)
+
+        raise IOError, Errno::ENOENT.new(path.to_s) if node.nil?
+
+        node.chmod!(mode)
+      end
+
       def readlines(path)
         path = Path[path]
         node = find(path)
@@ -155,6 +164,15 @@ module Dry
       def directory?(path)
         path = Path[path]
         !find_directory(path).nil?
+      end
+
+      def executable?(path)
+        path = Path[path]
+
+        node = find(path)
+        return false if node.nil?
+
+        node.executable?
       end
 
       private

--- a/lib/dry/files/memory_file_system.rb
+++ b/lib/dry/files/memory_file_system.rb
@@ -178,7 +178,7 @@ module Dry
       private
 
       def for_each_segment(path, &blk)
-        segments = path.split(::File::SEPARATOR)
+        segments = Path.split(path)
         segments.each(&blk)
       end
 

--- a/lib/dry/files/memory_file_system.rb
+++ b/lib/dry/files/memory_file_system.rb
@@ -28,7 +28,7 @@ module Dry
       end
 
       def pwd
-        @root.path
+        @root.segment
       end
 
       def cp(source, destination)
@@ -132,7 +132,7 @@ module Dry
           node = node.set(segment)
         end
 
-        node.file!(*content)
+        node.write(*content)
         node
       end
 
@@ -142,7 +142,7 @@ module Dry
 
         raise IOError, Errno::ENOENT.new(path.to_s) if node.nil?
 
-        node.chmod!(mode)
+        node.chmod = mode
       end
 
       def readlines(path)

--- a/lib/dry/files/memory_file_system/node.rb
+++ b/lib/dry/files/memory_file_system/node.rb
@@ -6,101 +6,237 @@ require "stringio"
 module Dry
   class Files
     class MemoryFileSystem
+      # Memory file system node (directory or file)
+      #
+      # @since 0.1.0
+      # @api private
+      #
+      # File modes implementation inspired by https://www.calleluks.com/flags-bitmasks-and-unix-file-system-permissions-in-ruby/
       class Node
-        # File mode inspired by https://www.calleluks.com/flags-bitmasks-and-unix-file-system-permissions-in-ruby/
-        MODE_USER_READ      = 0b100000000
-        MODE_USER_WRITE     = 0b010000000
-        MODE_USER_EXECUTE   = 0b001000000
-        MODE_GROUP_READ     = 0b000100000
-        MODE_GROUP_WRITE    = 0b000010000
-        MODE_GROUP_EXECUTE  = 0b000001000
-        MODE_OTHERS_READ    = 0b000000100
-        MODE_OTHERS_WRITE   = 0b000000010
-        MODE_OTHERS_EXECUTE = 0b000000001
-
+        # @since 0.1.0
+        # @api private
+        MODE_USER_READ = 0b100000000
         private_constant :MODE_USER_READ
+
+        # @since 0.1.0
+        # @api private
+        MODE_USER_WRITE = 0b010000000
         private_constant :MODE_USER_WRITE
+
+        # @since 0.1.0
+        # @api private
+        MODE_USER_EXECUTE = 0b001000000
         private_constant :MODE_USER_EXECUTE
+
+        # @since 0.1.0
+        # @api private
+        MODE_GROUP_READ = 0b000100000
         private_constant :MODE_GROUP_READ
+
+        # @since 0.1.0
+        # @api private
+        MODE_GROUP_WRITE = 0b000010000
         private_constant :MODE_GROUP_WRITE
+
+        # @since 0.1.0
+        # @api private
+        MODE_GROUP_EXECUTE = 0b000001000
         private_constant :MODE_GROUP_EXECUTE
+
+        # @since 0.1.0
+        # @api private
+        MODE_OTHERS_READ = 0b000000100
         private_constant :MODE_OTHERS_READ
+
+        # @since 0.1.0
+        # @api private
+        MODE_OTHERS_WRITE = 0b000000010
         private_constant :MODE_OTHERS_WRITE
+
+        # @since 0.1.0
+        # @api private
+        MODE_OTHERS_EXECUTE = 0b000000001
         private_constant :MODE_OTHERS_EXECUTE
 
-        DEFAULT_DIRECTORY_MODE = MODE_USER_READ | MODE_USER_WRITE |
-                                 MODE_USER_EXECUTE | MODE_GROUP_READ | MODE_GROUP_EXECUTE |
+        # Default directory mode: 0755
+        #
+        # @since 0.1.0
+        # @api private
+        DEFAULT_DIRECTORY_MODE = MODE_USER_READ | MODE_USER_WRITE | MODE_USER_EXECUTE |
+                                 MODE_GROUP_READ | MODE_GROUP_EXECUTE |
                                  MODE_OTHERS_READ | MODE_GROUP_EXECUTE
         private_constant :DEFAULT_DIRECTORY_MODE
 
+        # Default file mode: 0644
+        #
+        # @since 0.1.0
+        # @api private
         DEFAULT_FILE_MODE = MODE_USER_READ | MODE_USER_WRITE | MODE_GROUP_READ | MODE_OTHERS_READ
         private_constant :DEFAULT_FILE_MODE
 
+        # @since 0.1.0
+        # @api private
         MODE_BASE = 16
         private_constant :MODE_BASE
 
+        # @since 0.1.0
+        # @api private
         ROOT_PATH = "/"
         private_constant :ROOT_PATH
 
+        # Instantiate a root node
+        #
+        # @return [Dry::Files::MemoryFileSystem::Node] the root node
+        #
+        # @since 0.1.0
+        # @api private
         def self.root
           new(ROOT_PATH)
         end
 
-        attr_reader :path, :mode
+        # @since 0.1.0
+        # @api private
+        attr_reader :segment, :mode
 
-        def initialize(path, mode = DEFAULT_DIRECTORY_MODE)
-          @path = path
+        # Instantiate a new node.
+        # It's a directory node by default.
+        #
+        # @param segment [String] the path segment of the node
+        # @param mode [Integer] the UNIX mode
+        #
+        # @return [Dry::Files::MemoryFileSystem::Node] the new node
+        #
+        # @see #mode=
+        #
+        # @since 0.1.0
+        # @api private
+        def initialize(segment, mode = DEFAULT_DIRECTORY_MODE)
+          @segment = segment
           @children = nil
           @content = nil
 
-          chmod!(mode)
+          self.chmod = mode
         end
 
+        # Get a node child
+        #
+        # @param segment [String] the child path segment
+        #
+        # @return [Dry::Files::MemoryFileSystem::Node,NilClass] the child node, if found
+        #
+        # @since 0.1.0
+        # @api private
         def get(segment)
           @children&.fetch(segment, nil)
         end
 
+        # Set a node child
+        #
+        # @param segment [String] the child path segment
+        #
+        # @since 0.1.0
+        # @api private
         def set(segment)
           @children ||= {}
           @children[segment] ||= self.class.new(segment)
         end
 
+        # Unset a node child
+        #
+        # @param segment [String] the child path segment
+        #
+        # @raise [Dry::Files::UnknownMemoryNodeError] if the child node cannot be found
+        #
+        # @since 0.1.0
+        # @api private
         def unset(segment)
           @children ||= {}
-          raise UnknownMemoryNode, segment unless @children.key?(segment)
+          raise UnknownMemoryNodeError, segment unless @children.key?(segment)
 
           @children.delete(segment)
         end
 
+        # Check if node is a directory
+        #
+        # @return [TrueClass,FalseClass] the result of the check
+        #
+        # @since 0.1.0
+        # @api private
         def directory?
           !file?
         end
 
+        # Check if node is a file
+        #
+        # @return [TrueClass,FalseClass] the result of the check
+        #
+        # @since 0.1.0
+        # @api private
         def file?
           !@content.nil?
         end
 
-        def file!(*content)
-          @content = StringIO.new(content.join($RS))
-          @mode = DEFAULT_FILE_MODE
-        end
-
-        alias_method :write, :file!
-
+        # Read file contents
+        #
+        # @return [String] the file contents
+        #
+        # @raise [Dry::Files::NotMemoryFileError] if node isn't a file
+        #
+        # @since 0.1.0
+        # @api private
         def read
+          raise NotMemoryFileError, segment unless file?
+
           @content.rewind
           @content.read
         end
 
+        # Read file content lines
+        #
+        # @return [Array<String>] the file content lines
+        #
+        # @raise [Dry::Files::NotMemoryFileError] if node isn't a file
+        #
+        # @since 0.1.0
+        # @api private
         def readlines
+          raise NotMemoryFileError, segment unless file?
+
           @content.rewind
           @content.readlines
         end
 
-        def chmod!(mode)
+        # Write file contents
+        # IMPORTANT: This operation turns a node into a file
+        #
+        # @param content [String, Array<String>] the file content
+        #
+        # @raise [Dry::Files::NotMemoryFileError] if node isn't a file
+        #
+        # @since 0.1.0
+        # @api private
+        def write(*content)
+          @content = StringIO.new(content.join($RS))
+          @mode = DEFAULT_FILE_MODE
+        end
+
+        # Set UNIX mode
+        # It accepts base 2, 8, 10, and 16 numbers
+        #
+        # @param mode [Integer] the file mode
+        #
+        # @since 0.1.0
+        # @api private
+        def chmod=(mode)
           @mode = mode.to_s(MODE_BASE).hex
         end
 
+        # Check if node is executable for user
+        #
+        # @return [TrueClass,FalseClass] the result of the check
+        #
+        # @since 0.1.0
+        # @api private
         def executable?
           (mode & MODE_USER_EXECUTE).positive?
         end

--- a/lib/dry/files/memory_file_system/node.rb
+++ b/lib/dry/files/memory_file_system/node.rb
@@ -7,18 +7,33 @@ module Dry
   class Files
     class MemoryFileSystem
       class Node
-        def initialize
+        ROOT_PATH = "/"
+        private_constant :ROOT_PATH
+
+        def self.root
+          new(ROOT_PATH)
+        end
+
+        attr_reader :path
+
+        def initialize(path)
+          @path = path
           @children = nil
           @content = nil
         end
 
-        def put(segment)
-          @children ||= {}
-          @children[segment] ||= self.class.new
-        end
-
         def get(segment)
           @children&.fetch(segment, nil)
+        end
+
+        def put(segment)
+          @children ||= {}
+          @children[segment] ||= self.class.new(segment)
+        end
+
+        def unset(segment)
+          @children ||= {}
+          @children.delete(segment)
         end
 
         def directory?

--- a/lib/dry/files/memory_file_system/node.rb
+++ b/lib/dry/files/memory_file_system/node.rb
@@ -7,6 +7,38 @@ module Dry
   class Files
     class MemoryFileSystem
       class Node
+        # File mode inspired by https://www.calleluks.com/flags-bitmasks-and-unix-file-system-permissions-in-ruby/
+        MODE_USER_READ      = 0b100000000
+        MODE_USER_WRITE     = 0b010000000
+        MODE_USER_EXECUTE   = 0b001000000
+        MODE_GROUP_READ     = 0b000100000
+        MODE_GROUP_WRITE    = 0b000010000
+        MODE_GROUP_EXECUTE  = 0b000001000
+        MODE_OTHERS_READ    = 0b000000100
+        MODE_OTHERS_WRITE   = 0b000000010
+        MODE_OTHERS_EXECUTE = 0b000000001
+
+        private_constant :MODE_USER_READ
+        private_constant :MODE_USER_WRITE
+        private_constant :MODE_USER_EXECUTE
+        private_constant :MODE_GROUP_READ
+        private_constant :MODE_GROUP_WRITE
+        private_constant :MODE_GROUP_EXECUTE
+        private_constant :MODE_OTHERS_READ
+        private_constant :MODE_OTHERS_WRITE
+        private_constant :MODE_OTHERS_EXECUTE
+
+        DEFAULT_DIRECTORY_MODE = MODE_USER_READ | MODE_USER_WRITE |
+                                 MODE_USER_EXECUTE | MODE_GROUP_READ | MODE_GROUP_EXECUTE |
+                                 MODE_OTHERS_READ | MODE_GROUP_EXECUTE
+        private_constant :DEFAULT_DIRECTORY_MODE
+
+        DEFAULT_FILE_MODE = MODE_USER_READ | MODE_USER_WRITE | MODE_GROUP_READ | MODE_OTHERS_READ
+        private_constant :DEFAULT_FILE_MODE
+
+        MODE_BASE = 16
+        private_constant :MODE_BASE
+
         ROOT_PATH = "/"
         private_constant :ROOT_PATH
 
@@ -14,12 +46,13 @@ module Dry
           new(ROOT_PATH)
         end
 
-        attr_reader :path
+        attr_reader :path, :mode
 
-        def initialize(path)
+        def initialize(path, mode = DEFAULT_DIRECTORY_MODE)
           @path = path
           @children = nil
           @content = nil
+          @mode = mode
         end
 
         def get(segment)
@@ -46,6 +79,7 @@ module Dry
 
         def file!(*content)
           @content = StringIO.new(content.join($RS))
+          @mode = DEFAULT_FILE_MODE
         end
 
         alias_method :write, :file!
@@ -58,6 +92,14 @@ module Dry
         def readlines
           @content.rewind
           @content.readlines
+        end
+
+        def chmod!(mode)
+          @mode = mode.to_s(MODE_BASE).hex
+        end
+
+        def executable?
+          (mode & MODE_USER_EXECUTE).positive?
         end
       end
     end

--- a/lib/dry/files/memory_file_system/node.rb
+++ b/lib/dry/files/memory_file_system/node.rb
@@ -52,7 +52,8 @@ module Dry
           @path = path
           @children = nil
           @content = nil
-          @mode = mode
+
+          chmod!(mode)
         end
 
         def get(segment)
@@ -66,6 +67,8 @@ module Dry
 
         def unset(segment)
           @children ||= {}
+          raise UnknownMemoryNode, segment unless @children.key?(segment)
+
           @children.delete(segment)
         end
 

--- a/lib/dry/files/memory_file_system/node.rb
+++ b/lib/dry/files/memory_file_system/node.rb
@@ -59,7 +59,7 @@ module Dry
           @children&.fetch(segment, nil)
         end
 
-        def put(segment)
+        def set(segment)
           @children ||= {}
           @children[segment] ||= self.class.new(segment)
         end

--- a/lib/dry/files/path.rb
+++ b/lib/dry/files/path.rb
@@ -8,11 +8,11 @@ module Dry
     # are transformed into portable paths that respect the Operating System
     # directory separator.
     module Path
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       SEPARATOR = ::File::SEPARATOR
 
-      # @since x.x.x
+      # @since 0.1.0
       # @api private
       EMPTY_TOKEN = ""
       private_constant :EMPTY_TOKEN

--- a/lib/dry/files/path.rb
+++ b/lib/dry/files/path.rb
@@ -2,12 +2,48 @@
 
 module Dry
   class Files
+    # Cross Operating System path
+    #
+    # It's used by the memory adapter to ensure that hardcoded string paths
+    # are transformed into portable paths that respect the Operating System
+    # directory separator.
     module Path
       class << self
+        # Transform the given path into a path that respect the Operating System
+        # directory separator.
+        #
+        # @param path [String,Pathname,Array<String,Pathname>] the path to transform
+        #
+        # @return [String] the resulting path
+        #
+        # @since 0.1.0
+        # @api private
+        #
+        # @example Portable path
+        #   require "dry/files/path"
+        #
+        #   path = "path/to/file"
+        #
+        #   Dry::Files::Path.call(path)
+        #     # => "path/to/file" on UNIX based Operating System
+        #
+        #   Dry::Files::Path.call(path)
+        #     # => "path\to\file" on Windows Operating System
+        #
+        # @example Join nested tokens
+        #   require "dry/files/path"
+        #
+        #   path = ["path", ["to", ["nested", "file"]]]
+        #
+        #   Dry::Files::Path.call(path)
+        #     # => "path/to/nested/file" on UNIX based Operating System
+        #
+        #   Dry::Files::Path.call(path)
+        #     # => "path\to\nested\file" on Windows Operating System
         def call(*path)
           path = Array(path).flatten
           tokens = path.map do |token|
-            token.to_s.split(%r{\\|/})
+            split(token)
           end
 
           tokens
@@ -15,6 +51,18 @@ module Dry
             .join(::File::SEPARATOR)
         end
         alias_method :[], :call
+      end
+
+      # Split path according to the current Operating System directory separator
+      #
+      # @param path [String,Pathname] the path to split
+      #
+      # @return [Array<String>] the split path
+      #
+      # @since 0.1.0
+      # @api private
+      def self.split(path)
+        path.to_s.split(%r{\\|/})
       end
     end
   end

--- a/lib/dry/files/path.rb
+++ b/lib/dry/files/path.rb
@@ -7,7 +7,7 @@ module Dry
         def call(*path)
           path = Array(path).flatten
           tokens = path.map do |token|
-            token.split(%r{\\|/})
+            token.to_s.split(%r{\\|/})
           end
 
           tokens

--- a/lib/dry/files/path.rb
+++ b/lib/dry/files/path.rb
@@ -8,6 +8,11 @@ module Dry
     # are transformed into portable paths that respect the Operating System
     # directory separator.
     module Path
+      # @since x.x.x
+      # @api private
+      EMPTY_TOKEN = ""
+      private_constant :EMPTY_TOKEN
+
       class << self
         # Transform the given path into a path that respect the Operating System
         # directory separator.
@@ -19,7 +24,7 @@ module Dry
         # @since 0.1.0
         # @api private
         #
-        # @example Portable path
+        # @example Portable Path
         #   require "dry/files/path"
         #
         #   path = "path/to/file"
@@ -30,7 +35,7 @@ module Dry
         #   Dry::Files::Path.call(path)
         #     # => "path\to\file" on Windows Operating System
         #
-        # @example Join nested tokens
+        # @example Join Nested Tokens
         #   require "dry/files/path"
         #
         #   path = ["path", ["to", ["nested", "file"]]]
@@ -40,6 +45,14 @@ module Dry
         #
         #   Dry::Files::Path.call(path)
         #     # => "path\to\nested\file" on Windows Operating System
+        #
+        # @example Separator path
+        #   require "dry/files/path"
+        #
+        #   path = ::File::SEPARATOR
+        #
+        #   Dry::Files::Path.call(path)
+        #     # => ""
         def call(*path)
           path = Array(path).flatten
           tokens = path.map do |token|
@@ -62,6 +75,8 @@ module Dry
       # @since 0.1.0
       # @api private
       def self.split(path)
+        return EMPTY_TOKEN if path == ::File::SEPARATOR
+
         path.to_s.split(%r{\\|/})
       end
     end

--- a/lib/dry/files/path.rb
+++ b/lib/dry/files/path.rb
@@ -86,7 +86,7 @@ module Dry
 
       # Check if given path is absolute
       #
-      # @param path [String,Pathname] the path to transform
+      # @param path [String,Pathname] the path to check
       #
       # @return [TrueClass,FalseClass] the result of the check
       #
@@ -94,6 +94,18 @@ module Dry
       # @api private
       def self.absolute?(path)
         path.start_with?(SEPARATOR)
+      end
+
+      # Returns all the path, except for the last token
+      #
+      # @param path [String,Pathname] the path to extract directory name from
+      #
+      # @return [String] the directory name
+      #
+      # @since 0.1.0
+      # @api private
+      def self.dirname(path)
+        ::File.dirname(path)
       end
     end
   end

--- a/lib/dry/files/path.rb
+++ b/lib/dry/files/path.rb
@@ -10,6 +10,10 @@ module Dry
     module Path
       # @since x.x.x
       # @api private
+      SEPARATOR = ::File::SEPARATOR
+
+      # @since x.x.x
+      # @api private
       EMPTY_TOKEN = ""
       private_constant :EMPTY_TOKEN
 
@@ -61,7 +65,7 @@ module Dry
 
           tokens
             .flatten
-            .join(::File::SEPARATOR)
+            .join(SEPARATOR)
         end
         alias_method :[], :call
       end
@@ -75,9 +79,21 @@ module Dry
       # @since 0.1.0
       # @api private
       def self.split(path)
-        return EMPTY_TOKEN if path == ::File::SEPARATOR
+        return EMPTY_TOKEN if path == SEPARATOR
 
         path.to_s.split(%r{\\|/})
+      end
+
+      # Check if given path is absolute
+      #
+      # @param path [String,Pathname] the path to transform
+      #
+      # @return [TrueClass,FalseClass] the result of the check
+      #
+      # @since 0.1.0
+      # @api private
+      def self.absolute?(path)
+        path.start_with?(SEPARATOR)
       end
     end
   end

--- a/spec/integration/dry/files_spec.rb
+++ b/spec/integration/dry/files_spec.rb
@@ -606,7 +606,7 @@ RSpec.describe Dry::Files do
 
       expect { subject.replace_first_line(path, "not existing target", "  def self.call(input)") }.to raise_error do |exception|
         expect(exception).to be_kind_of(Dry::Files::MissingTargetError)
-        expect(exception.message).to eq("Cannot find `not existing target' in `#{path}'")
+        expect(exception.message).to eq("cannot find `not existing target' in `#{path}'")
       end
 
       expect(path).to have_content(content)
@@ -711,7 +711,7 @@ RSpec.describe Dry::Files do
 
       expect { subject.replace_last_line(path, "not existing target", "  def self.call(input)") }.to raise_error do |exception|
         expect(exception).to be_kind_of(Dry::Files::MissingTargetError)
-        expect(exception.message).to eq("Cannot find `not existing target' in `#{path}'")
+        expect(exception.message).to eq("cannot find `not existing target' in `#{path}'")
       end
 
       expect(path).to have_content(content)
@@ -790,7 +790,7 @@ RSpec.describe Dry::Files do
 
       expect { subject.inject_line_before(path, "not existing target", "  # It performs the operation") }.to raise_error do |exception|
         expect(exception).to be_kind_of(Dry::Files::MissingTargetError)
-        expect(exception.message).to eq("Cannot find `not existing target' in `#{path}'")
+        expect(exception.message).to eq("cannot find `not existing target' in `#{path}'")
       end
 
       expect(path).to have_content(content)
@@ -879,7 +879,7 @@ RSpec.describe Dry::Files do
 
       expect { subject.inject_line_before_last(path, "not existing target", "  # It performs the operation") }.to raise_error do |exception|
         expect(exception).to be_kind_of(Dry::Files::MissingTargetError)
-        expect(exception.message).to eq("Cannot find `not existing target' in `#{path}'")
+        expect(exception.message).to eq("cannot find `not existing target' in `#{path}'")
       end
 
       expect(path).to have_content(content)
@@ -958,7 +958,7 @@ RSpec.describe Dry::Files do
 
       expect { subject.inject_line_after(path, "not existing target", "    :result") }.to raise_error do |exception|
         expect(exception).to be_kind_of(Dry::Files::MissingTargetError)
-        expect(exception.message).to eq("Cannot find `not existing target' in `#{path}'")
+        expect(exception.message).to eq("cannot find `not existing target' in `#{path}'")
       end
 
       expect(path).to have_content(content)
@@ -1047,7 +1047,7 @@ RSpec.describe Dry::Files do
 
       expect { subject.inject_line_after_last(path, "not existing target", "    :result") }.to raise_error do |exception|
         expect(exception).to be_kind_of(Dry::Files::MissingTargetError)
-        expect(exception.message).to eq("Cannot find `not existing target' in `#{path}'")
+        expect(exception.message).to eq("cannot find `not existing target' in `#{path}'")
       end
 
       expect(path).to have_content(content)
@@ -1127,7 +1127,7 @@ RSpec.describe Dry::Files do
 
       expect { subject.remove_line(path, "not existing target") }.to raise_error do |exception|
         expect(exception).to be_kind_of(Dry::Files::MissingTargetError)
-        expect(exception.message).to eq("Cannot find `not existing target' in `#{path}'")
+        expect(exception.message).to eq("cannot find `not existing target' in `#{path}'")
       end
 
       expect(path).to have_content(content)
@@ -1278,7 +1278,7 @@ RSpec.describe Dry::Files do
 
       expect { subject.inject_line_at_block_top(path, "configure", "") }.to raise_error do |exception|
         expect(exception).to be_kind_of(Dry::Files::MissingTargetError)
-        expect(exception.message).to eq("Cannot find `configure' in `#{path.realpath}'")
+        expect(exception.message).to eq("cannot find `configure' in `#{path.realpath}'")
       end
     end
   end
@@ -1415,7 +1415,7 @@ RSpec.describe Dry::Files do
 
       expect { subject.inject_line_at_block_top(path, "configure", "") }.to raise_error do |exception|
         expect(exception).to be_kind_of(Dry::Files::MissingTargetError)
-        expect(exception.message).to eq("Cannot find `configure' in `#{path.realpath}'")
+        expect(exception.message).to eq("cannot find `configure' in `#{path.realpath}'")
       end
     end
   end
@@ -1497,7 +1497,7 @@ RSpec.describe Dry::Files do
 
       expect { subject.remove_block(path, "not existing target") }.to raise_error do |exception|
         expect(exception).to be_kind_of(Dry::Files::MissingTargetError)
-        expect(exception.message).to eq("Cannot find `not existing target' in `#{path}'")
+        expect(exception.message).to eq("cannot find `not existing target' in `#{path}'")
       end
 
       expect(path).to have_content(content)

--- a/spec/integration/dry/files_spec.rb
+++ b/spec/integration/dry/files_spec.rb
@@ -372,19 +372,38 @@ RSpec.describe Dry::Files do
         expect(exception.message).to include(path.to_s)
       end
     end
+
+    it "raises error if path is a directory" do
+      path = root.join("delete", "directory")
+      path.mkpath
+
+      expect { subject.delete(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::EPERM)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
   end
 
   describe "#delete_directory" do
     it "deletes directory" do
-      path = root.join("delete", "directory")
+      path = root.join("delete_directory", "directory")
       subject.mkdir(path)
       subject.delete_directory(path)
 
       expect(path).to_not exist
     end
 
+    it "deletes a file" do
+      path = root.join("delete_directory", "file")
+      subject.touch(path)
+      subject.delete_directory(path)
+
+      expect(path).to_not exist
+    end
+
     it "raises error if directory doesn't exist" do
-      path = root.join("delete", "directory")
+      path = root.join("delete_directory", "directory")
 
       expect { subject.delete_directory(path) }.to raise_error do |exception|
         expect(exception).to be_kind_of(Dry::Files::IOError)
@@ -1504,7 +1523,7 @@ RSpec.describe Dry::Files do
       path = root.join("directory-dir")
       subject.mkdir(path)
 
-      expect(subject.exist?(path)).to be(true)
+      expect(subject.directory?(path)).to be(true)
     end
 
     it "returns false for file" do

--- a/spec/integration/dry/files_spec.rb
+++ b/spec/integration/dry/files_spec.rb
@@ -380,12 +380,18 @@ RSpec.describe Dry::Files do
       expect { subject.delete(path) }.to raise_error do |exception|
         expect(exception).to be_kind_of(Dry::Files::IOError)
 
-        with_operating_system(:macos) do
-          expect(exception.cause).to be_kind_of(Errno::EPERM)
+        with_ruby_engine(:mri) do
+          with_operating_system(:macos) do
+            expect(exception.cause).to be_kind_of(Errno::EPERM)
+          end
+
+          with_operating_system(:linux) do
+            expect(exception.cause).to be_kind_of(Errno::EISDIR)
+          end
         end
 
-        with_operating_system(:linux) do
-          expect(exception.cause).to be_kind_of(Errno::EISDIR)
+        with_ruby_engine(:jruby) do
+          expect(exception.cause).to be_kind_of(Errno::EPERM)
         end
 
         expect(exception.message).to include(path.to_s)

--- a/spec/integration/dry/files_spec.rb
+++ b/spec/integration/dry/files_spec.rb
@@ -379,7 +379,15 @@ RSpec.describe Dry::Files do
 
       expect { subject.delete(path) }.to raise_error do |exception|
         expect(exception).to be_kind_of(Dry::Files::IOError)
-        expect(exception.cause).to be_kind_of(Errno::EPERM)
+
+        with_operating_system(:macos) do
+          expect(exception.cause).to be_kind_of(Errno::EPERM)
+        end
+
+        with_operating_system(:linux) do
+          expect(exception.cause).to be_kind_of(Errno::EISDIR)
+        end
+
         expect(exception.message).to include(path.to_s)
       end
     end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -8,6 +8,26 @@ RSpec::Matchers.define :have_content do |expected|
   end
 
   failure_message do |actual|
-    "expected that `#{actual}' would be have content '#{expected}', but it has '#{File.read(actual)}'" # rubocop:disable Metrics/LineLength
+    "expected that `#{actual}' would have content '#{expected}', but it has '#{File.read(actual)}'"
+  end
+end
+
+RSpec::Matchers.define :be_found do
+  match do |actual|
+    subject.exist?(actual)
+  end
+
+  failure_message do |actual|
+    "expected `#{actual}' to exist"
+  end
+end
+
+RSpec::Matchers.define :have_file_contents do |expected|
+  match do |actual|
+    subject.read(actual) == expected
+  end
+
+  failure_message do |actual|
+    "expected that `#{actual}' would have content '#{expected}', but it has '#{subject.read(actual)}'" # rubocop:disable Layout/LineLength
   end
 end

--- a/spec/support/os.rb
+++ b/spec/support/os.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rbconfig"
+
+module RSpec
+  module Helpers
+    module OS
+      private
+
+      def with_operating_system(os, &blk)
+        result = case host_os = RbConfig::CONFIG["host_os"]
+                 when /linux/ then :linux
+                 when /darwin/ then :macos
+                 when /win32|mingw|bccwin|cygwin/ then :windows
+                 else
+                   raise "unkwnown OS: `#{host_os}'"
+                 end
+
+        blk.call if result == os
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include(RSpec::Helpers::OS)
+end

--- a/spec/support/ruby_engine.rb
+++ b/spec/support/ruby_engine.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module RSpec
+  module Helpers
+    module RubyEngine
+      private
+
+      def with_ruby_engine(engine, &blk)
+        result = if RUBY_ENGINE == "ruby"
+                   :mri
+                 elsif RUBY_PLATFORM == "java"
+                   :jruby
+                 else
+                   raise "unkwnown Ruby engine: `#{result}'"
+                 end
+
+        blk.call if result == engine
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include(RSpec::Helpers::RubyEngine)
+end

--- a/spec/unit/dry/files/adapter_spec.rb
+++ b/spec/unit/dry/files/adapter_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Files::Adapter do
+  describe ".call" do
+    let(:subject) { described_class.call(memory: memory) }
+
+    context "memory: true" do
+      let(:memory) { true }
+
+      it "returns memory file system adapter" do
+        expect(subject).to be_kind_of(Dry::Files::MemoryFileSystem)
+      end
+    end
+
+    context "memory: false" do
+      let(:memory) { false }
+
+      it "returns real file system adapter" do
+        expect(subject).to be_kind_of(Dry::Files::FileSystem)
+      end
+    end
+  end
+end

--- a/spec/unit/dry/files/error_spec.rb
+++ b/spec/unit/dry/files/error_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Files::Error do
+  it "inherits from StandardError" do
+    expect(subject).to be_kind_of(described_class)
+    expect(subject).to be_kind_of(StandardError)
+  end
+end
+
+RSpec.describe Dry::Files::IOError do
+  subject { described_class.new(cause) }
+  let(:cause) { Errno::ENOENT.new(Dir.pwd) }
+
+  it "inherits from Dry::Files::Error" do
+    expect(subject).to be_kind_of(Dry::Files::Error)
+  end
+
+  it "wraps low level I/O error" do
+    expect(subject.message).to eq(cause.message)
+    expect(subject.cause).to eq(cause)
+  end
+end
+
+RSpec.describe Dry::Files::MissingTargetError do
+  subject { described_class.new(target, path) }
+  let(:target) { /rspec/i }
+  let(:path) { Pathname.new(__FILE__) }
+
+  it "inherits from Dry::Files::Error" do
+    expect(subject).to be_kind_of(Dry::Files::Error)
+  end
+
+  it "exposes error information" do
+    expect(subject.message).to eq("cannot find `#{target}' in `#{path}'")
+    expect(subject.target).to eq(target)
+    expect(subject.path).to eq(path)
+  end
+end

--- a/spec/unit/dry/files/file_system_spec.rb
+++ b/spec/unit/dry/files/file_system_spec.rb
@@ -235,10 +235,10 @@ RSpec.describe Dry::Files::FileSystem do
   describe "#chdir" do
     it "changes current working directory" do
       current_directory = subject.pwd
-      subject.mkdir(dir = "path/to/dir")
+      subject.mkdir(dir = root.join("chdir/to/dir").to_s)
 
       subject.chdir(dir) do
-        expect(subject.pwd).to eq(subject.join(current_directory, dir))
+        expect(subject.pwd).to eq(dir)
       end
 
       expect(subject.pwd).to eq(current_directory)

--- a/spec/unit/dry/files/file_system_spec.rb
+++ b/spec/unit/dry/files/file_system_spec.rb
@@ -364,7 +364,14 @@ RSpec.describe Dry::Files::FileSystem do
 
       expect { subject.rm(path) }.to raise_error do |exception|
         expect(exception).to be_kind_of(Dry::Files::IOError)
-        expect(exception.cause).to be_kind_of(Errno::EPERM)
+
+        with_operating_system(:macos) do
+          expect(exception.cause).to be_kind_of(Errno::EPERM)
+        end
+
+        with_operating_system(:linux) do
+          expect(exception.cause).to be_kind_of(Errno::EISDIR)
+        end
         expect(exception.message).to include(path.to_s)
       end
     end

--- a/spec/unit/dry/files/file_system_spec.rb
+++ b/spec/unit/dry/files/file_system_spec.rb
@@ -1,0 +1,522 @@
+# frozen_string_literal: true
+
+require "dry/files/file_system"
+require "securerandom"
+require "English"
+
+RSpec.describe Dry::Files::FileSystem do
+  let(:root) { Pathname.new(Dir.pwd).join("tmp", SecureRandom.uuid).tap(&:mkpath) }
+  let(:newline) { $INPUT_RECORD_SEPARATOR }
+
+  after do
+    FileUtils.remove_entry_secure(root)
+  end
+
+  describe "#touch" do
+    it "creates an empty file" do
+      path = root.join("touch")
+      subject.touch(path)
+
+      expect(path).to be_found
+      expect(path).to have_file_contents("")
+    end
+
+    it "creates intermediate directories" do
+      path = root.join("path", "to", "file", "touch")
+      subject.touch(path)
+
+      expect(path).to be_found
+      expect(path).to have_file_contents("")
+    end
+
+    xit "leaves untouched existing file" do
+      path = root.join("touch")
+      subject.write(path, "foo")
+      subject.touch(path)
+
+      expect(path).to be_found
+      expect(path).to have_file_contents("foo")
+    end
+
+    it "raises error if path is a directory" do
+      path = root.join("touch-directory")
+      subject.mkdir(path)
+
+      expect { subject.touch(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::EISDIR)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+  end
+
+  describe "#read" do
+    it "reads file" do
+      path = root.join("read")
+      subject.write(path, expected = "Hello#{newline}World")
+
+      expect(subject.read(path)).to eq(expected)
+    end
+
+    it "raises error when path is a directory" do
+      path = root.join("read-directory")
+      subject.mkdir(path)
+
+      expect { subject.read(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::EISDIR)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+
+    it "raises error when path doesn't exist" do
+      path = root.join("read-does-not-exist")
+
+      expect { subject.read(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+  end
+
+  describe "#write" do
+    it "creates an file with given contents" do
+      path = root.join("write")
+      subject.write(path, "Hello#{newline}World")
+
+      expect(path).to be_found
+      expect(path).to have_file_contents("Hello#{newline}World")
+    end
+
+    it "creates intermediate directories" do
+      path = root.join("path", "to", "file", "write")
+      subject.write(path, ":)")
+
+      expect(path).to be_found
+      expect(path).to have_file_contents(":)")
+    end
+
+    it "overwrites file when it already exist" do
+      path = root.join("write")
+      subject.write(path, "many many many many words")
+      subject.write(path, "new words")
+
+      expect(path).to be_found
+      expect(path).to have_file_contents("new words")
+    end
+
+    xit "raises error when path isn't writeable" do
+      path = root.join("write-not-writeable")
+      path.mkpath
+      mode = path.stat.mode
+
+      begin
+        path.chmod(0o000)
+
+        expect { subject.write(path.join("file-not-writeable"), "content") }.to raise_error do |exception|
+          expect(exception).to be_kind_of(Dry::Files::IOError)
+          expect(exception.cause).to be_kind_of(Errno::EACCES)
+          expect(exception.message).to include(path.to_s)
+        end
+      ensure
+        path.chmod(mode)
+      end
+    end
+  end
+
+  describe "#cp" do
+    let(:source) { root.join("..", "source") }
+
+    before do
+      subject.rm(source) if subject.exist?(source)
+    end
+
+    it "creates a file with given contents" do
+      subject.write(source, "the source")
+
+      destination = root.join("cp")
+      subject.cp(source, destination)
+
+      expect(destination).to be_found
+      expect(destination).to have_file_contents("the source")
+    end
+
+    it "creates intermediate directories" do
+      source = root.join("..", "source")
+      subject.write(source, "the source for intermediate directories")
+
+      destination = root.join("cp", "destination")
+      subject.cp(source, destination)
+
+      expect(destination).to be_found
+      expect(destination).to have_file_contents("the source for intermediate directories")
+    end
+
+    it "overrides already existing file" do
+      source = root.join("..", "source")
+      subject.write(source, "the source")
+
+      destination = root.join("cp")
+      subject.write(destination, "the destination")
+      subject.cp(source, destination)
+
+      expect(destination).to be_found
+      expect(destination).to have_file_contents("the source")
+    end
+
+    it "raises error when source cannot be found" do
+      source = root.join("missing-source")
+      destination = root.join("cp")
+
+      expect { subject.cp(source, destination) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(source.to_s)
+      end
+    end
+  end
+
+  describe "#join" do
+    it "joins a single entry" do
+      path = "path"
+      expect(root.join(path)).to eq(path)
+
+      path = Pathname.new(path)
+      expect(root.join(path)).to eq(path.to_s)
+    end
+
+    it "joins multiple entries" do
+      path = %w[path to file]
+      expected = path.join(File::SEPARATOR)
+
+      expect(root.join(path)).to eq(expected)
+
+      path = path.map { |p| Pathname.new(p) }
+      expect(root.join(path)).to eq(expected)
+    end
+  end
+
+  xdescribe "#expand_path" do
+    it "expands path from current directory" do
+      path = "expand-path"
+
+      begin
+        subject.touch(path)
+
+        expect(subject.expand_path(path, subject.pwd)).to eq(File.join(Dir.pwd, path))
+      ensure
+        FileUtils.rm_rf(path)
+      end
+    end
+
+    it "expands path from current directory in combination with chdir" do
+      path = root.join("expand-path", "dir", "file")
+      subject.touch(path)
+
+      subject.chdir(root.join("expand-path", "dir")) do
+        expect(subject.expand_path("file")).to eq(path.realpath.to_s)
+      end
+    end
+
+    it "expands path from given directory" do
+      dir = root.join("expand-path", "given-dir")
+      path = dir.join("file")
+      subject.touch(path)
+
+      expect(subject.expand_path("file", dir)).to eq(path.realpath.to_s)
+    end
+
+    it "returns absolute path as it is" do
+      path = root.join("expand-path", "absolute")
+      subject.touch(path)
+
+      expect(subject.expand_path(path.realpath)).to eq(path.realpath.to_s)
+    end
+  end
+
+  describe "#pwd" do
+    it "returns root directory by default" do
+      expect(subject.pwd).to eq("/")
+    end
+  end
+
+  describe "#chdir" do
+    it "changes current working directory" do
+      current_directory = subject.pwd
+      subject.mkdir(dir = "path/to/dir")
+
+      subject.chdir(dir) do
+        expect(subject.pwd).to eq("dir")
+      end
+
+      expect(subject.pwd).to eq(current_directory)
+    end
+
+    it "raises error if directory cannot be found" do
+      path = root.join("chdir-non-existing")
+
+      expect { subject.chdir(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+
+    it "raises error if argument is a file" do
+      path = root.join("chdir-file")
+      subject.touch(path)
+
+      expect { subject.chdir(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOTDIR)
+        expect(exception.message).to match(path.to_s)
+      end
+    end
+  end
+
+  describe "#mkdir" do
+    it "creates directory" do
+      path = root.join("mkdir")
+      subject.mkdir(path)
+
+      expect(subject.directory?(path)).to be(true)
+    end
+
+    it "creates intermediate directories" do
+      path = root.join("path", "to", "mkdir")
+      subject.mkdir(path)
+
+      expect(subject.directory?(path)).to be(true)
+    end
+
+    xit "raises error when path isn't writeable" do
+      path = root.join("mkdir-not-writeable")
+      path.mkpath
+      mode = path.stat.mode
+
+      begin
+        path.chmod(0o000)
+
+        expect { subject.mkdir(path.join("dir-not-writeable")) }.to raise_error do |exception|
+          expect(exception).to be_kind_of(Dry::Files::IOError)
+          expect(exception.cause).to be_kind_of(Errno::EACCES)
+          expect(exception.message).to include(path.to_s)
+        end
+      ensure
+        path.chmod(mode)
+      end
+    end
+  end
+
+  describe "#mkdir_p" do
+    it "creates directory" do
+      directory = root.join("mkdir_p")
+      path = root.join(directory, "file.rb")
+      subject.mkdir_p(path)
+
+      expect(subject.directory?(directory)).to be(true)
+      expect(path).to_not be_found
+    end
+
+    it "creates intermediate directories" do
+      directory = root.join("path", "to", "mkdir_p")
+      path = root.join(directory, "file.rb")
+      subject.mkdir_p(path)
+
+      expect(subject.directory?(directory)).to be(true)
+      expect(path).to_not be_found
+    end
+
+    xit "raises error when path isn't writeable" do
+      parent = root.join("path")
+      parent.mkpath
+      mode = parent.stat.mode
+
+      begin
+        parent.chmod(0o000)
+        path = parent.join("to", "mkdir_p", "dir-not-writeable")
+
+        expect { subject.mkdir_p(path) }.to raise_error do |exception|
+          expect(exception).to be_kind_of(Dry::Files::IOError)
+          expect(exception.cause).to be_kind_of(Errno::EACCES)
+          expect(exception.message).to include(parent.to_s)
+        end
+      ensure
+        parent.chmod(mode)
+      end
+    end
+  end
+
+  describe "#rm" do
+    it "deletes path" do
+      path = root.join("delete", "file")
+      subject.touch(path)
+      subject.rm(path)
+
+      expect(path).to_not be_found
+    end
+
+    it "raises error if path doesn't exist" do
+      path = root.join("delete", "file")
+
+      expect { subject.rm(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+
+    it "raises error if path is a directory" do
+      path = root.join("delete", "directory")
+      subject.mkdir(path)
+
+      expect { subject.rm(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::EPERM)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+  end
+
+  describe "#rm_rf" do
+    it "deletes directory" do
+      path = root.join("delete", "directory")
+      subject.mkdir(path)
+      subject.rm_rf(path)
+
+      expect(path).to_not be_found
+    end
+
+    it "deletes a file" do
+      path = root.join("delete_directory", "file")
+      subject.touch(path)
+      subject.rm_rf(path)
+
+      expect(path).to_not be_found
+    end
+
+    it "raises error if directory doesn't exist" do
+      path = root.join("delete", "directory")
+
+      expect { subject.rm_rf(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+  end
+
+  describe "#readlines" do
+    it "reads file and returns array of lines" do
+      path = root.join("readlines-file")
+      subject.write(path, "hello#{newline}world")
+
+      expect(subject.readlines(path)).to eq(%W[hello#{newline} world])
+    end
+
+    it "reads empty file and returns empty array" do
+      path = root.join("readlines-empty-file")
+      subject.touch(path)
+
+      expect(subject.readlines(path)).to eq([])
+    end
+
+    it "raises error if file doesn't exist" do
+      path = root.join("readlines-non-existing-file")
+
+      expect { subject.readlines(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+
+    it "raises error if path is a directory" do
+      path = root.join("readlines", "directory")
+      subject.mkdir(path)
+
+      expect { subject.readlines(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::EISDIR)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+
+    xit "it raises error if path isn't readable"
+  end
+
+  describe "#exist?" do
+    it "returns true for file" do
+      path = root.join("exist-file")
+      subject.touch(path)
+
+      expect(subject.exist?(path)).to be(true)
+    end
+
+    it "returns true for directory" do
+      path = root.join("exist-dir")
+      subject.mkdir(path)
+
+      expect(subject.exist?(path)).to be(true)
+    end
+
+    it "returns false for non-existing file" do
+      path = root.join("exist-non-existing")
+
+      expect(subject.exist?(path)).to be(false)
+    end
+  end
+
+  describe "#directory?" do
+    it "returns true for directory" do
+      path = root.join("directory-dir")
+      subject.mkdir(path)
+
+      expect(subject.directory?(path)).to be(true)
+    end
+
+    it "returns false for file" do
+      path = root.join("directory-file")
+      subject.touch(path)
+
+      expect(subject.directory?(path)).to be(false)
+    end
+
+    it "returns false for non-existing path" do
+      path = root.join("directory-non-existing")
+
+      expect(subject.directory?(path)).to be(false)
+    end
+  end
+
+  xdescribe "#executable?" do
+    it "returns true when file is executable" do
+      path = root.join("executable-exec")
+      subject.touch(path)
+      path.chmod(0o744)
+
+      expect(subject.executable?(path)).to be(true)
+    end
+
+    it "returns false when file isn't executable" do
+      path = root.join("executable-non-exec")
+      subject.touch(path)
+
+      expect(subject.executable?(path)).to be(false)
+    end
+
+    it "returns false when file doesn't exist" do
+      path = root.join("executable-non-existing")
+
+      expect(subject.executable?(path)).to be(false)
+    end
+
+    it "returns true for directory" do
+      path = root.join("executable-directory")
+      subject.mkdir(path)
+
+      expect(subject.executable?(path)).to be(true)
+    end
+  end
+end

--- a/spec/unit/dry/files/file_system_spec.rb
+++ b/spec/unit/dry/files/file_system_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Dry::Files::FileSystem do
       expect(path).to have_file_contents("")
     end
 
-    xit "leaves untouched existing file" do
+    it "leaves untouched existing file" do
       path = root.join("touch")
       subject.write(path, "foo")
       subject.touch(path)
@@ -106,7 +106,7 @@ RSpec.describe Dry::Files::FileSystem do
       expect(path).to have_file_contents("new words")
     end
 
-    xit "raises error when path isn't writeable" do
+    it "raises error when path isn't writeable" do
       path = root.join("write-not-writeable")
       path.mkpath
       mode = path.stat.mode

--- a/spec/unit/dry/files/file_system_spec.rb
+++ b/spec/unit/dry/files/file_system_spec.rb
@@ -365,13 +365,20 @@ RSpec.describe Dry::Files::FileSystem do
       expect { subject.rm(path) }.to raise_error do |exception|
         expect(exception).to be_kind_of(Dry::Files::IOError)
 
-        with_operating_system(:macos) do
+        with_ruby_engine(:mri) do
+          with_operating_system(:macos) do
+            expect(exception.cause).to be_kind_of(Errno::EPERM)
+          end
+
+          with_operating_system(:linux) do
+            expect(exception.cause).to be_kind_of(Errno::EISDIR)
+          end
+        end
+
+        with_ruby_engine(:jruby) do
           expect(exception.cause).to be_kind_of(Errno::EPERM)
         end
 
-        with_operating_system(:linux) do
-          expect(exception.cause).to be_kind_of(Errno::EISDIR)
-        end
         expect(exception.message).to include(path.to_s)
       end
     end

--- a/spec/unit/dry/files/memory_file_system/node_spec.rb
+++ b/spec/unit/dry/files/memory_file_system/node_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "dry/files/memory_file_system/node"
+
+RSpec.describe Dry::Files::MemoryFileSystem::Node do
+  subject { described_class.new(path) }
+  let(:path) { "/foo" }
+
+  describe ".root" do
+    subject { described_class.root }
+
+    it "returns a root node" do
+      expect(subject).to be_kind_of(described_class)
+      expect(subject.path).to eq("/")
+    end
+  end
+
+  describe "#initialize" do
+    it "is instance of #{described_class}" do
+      expect(subject).to be_kind_of(described_class)
+    end
+
+    context "path" do
+      it "accepts path argument" do
+        expect(subject.path).to eq(path)
+      end
+    end
+
+    context "mode" do
+      it "defaults to directory mode" do
+        expected = 0b111101100 # 0644
+        expect(subject.mode).to eq(expected)
+      end
+
+      it "accepts optional mode argument (hex)" do
+        mode = 0b100000000 # 0400
+        subject = described_class.new(path, mode)
+
+        expect(subject.mode).to eq(mode)
+      end
+
+      it "accepts optional mode argument (oct)" do
+        mode = 0o400
+        subject = described_class.new(path, mode)
+
+        expected = 0b100000000 # 0400
+        expect(subject.mode).to eq(expected)
+      end
+    end
+  end
+
+  describe "#get" do
+    before { subject.set(segment) }
+    let(:segment) { "tmp" }
+
+    it "returns child node" do
+      current = subject.get(segment)
+      expect(current).to be_kind_of(described_class)
+      expect(current.path).to eq(segment)
+    end
+
+    it "returns nil when given segment doesn't match any children" do
+      expect(subject.get("foo")).to be(nil)
+    end
+  end
+
+  describe "#set" do
+    let(:segment) { "tmp" }
+
+    it "sets child node" do
+      subject.set(segment)
+
+      current = subject.get(segment)
+      expect(current).to be_kind_of(described_class)
+      expect(current.path).to eq(segment)
+    end
+
+    it "doesn't override existing node" do
+      subject.set(segment)
+      current = subject.get(segment)
+      subject.set(segment) # override attempt
+
+      expect(subject.get(segment).object_id).to eq(current.object_id)
+    end
+  end
+
+  describe "#unset" do
+    before { subject.set(segment) }
+    let(:segment) { "tmp" }
+
+    it "removes child" do
+      subject.unset(segment)
+      expect(subject.get(segment)).to be(nil)
+    end
+
+    it "raises error if trying to remove unexisting child" do
+      expect { subject.unset("foo") }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::UnknownMemoryNode)
+        expect(exception.message).to eq("unknown memory node `foo'")
+      end
+    end
+  end
+end

--- a/spec/unit/dry/files/memory_file_system/node_spec.rb
+++ b/spec/unit/dry/files/memory_file_system/node_spec.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
 require "dry/files/memory_file_system/node"
+require "English"
 
 RSpec.describe Dry::Files::MemoryFileSystem::Node do
   subject { described_class.new(path) }
-  let(:path) { "/foo" }
+  let(:path) { "/usr" }
+  let(:newline) { $RS }
 
   describe ".root" do
     subject { described_class.root }
 
     it "returns a root node" do
       expect(subject).to be_kind_of(described_class)
-      expect(subject.path).to eq("/")
+      expect(subject.segment).to eq("/")
     end
   end
 
@@ -22,7 +24,7 @@ RSpec.describe Dry::Files::MemoryFileSystem::Node do
 
     context "path" do
       it "accepts path argument" do
-        expect(subject.path).to eq(path)
+        expect(subject.segment).to eq(path)
       end
     end
 
@@ -56,7 +58,7 @@ RSpec.describe Dry::Files::MemoryFileSystem::Node do
     it "returns child node" do
       current = subject.get(segment)
       expect(current).to be_kind_of(described_class)
-      expect(current.path).to eq(segment)
+      expect(current.segment).to eq(segment)
     end
 
     it "returns nil when given segment doesn't match any children" do
@@ -72,7 +74,7 @@ RSpec.describe Dry::Files::MemoryFileSystem::Node do
 
       current = subject.get(segment)
       expect(current).to be_kind_of(described_class)
-      expect(current.path).to eq(segment)
+      expect(current.segment).to eq(segment)
     end
 
     it "doesn't override existing node" do
@@ -95,9 +97,135 @@ RSpec.describe Dry::Files::MemoryFileSystem::Node do
 
     it "raises error if trying to remove unexisting child" do
       expect { subject.unset("foo") }.to raise_error do |exception|
-        expect(exception).to be_kind_of(Dry::Files::UnknownMemoryNode)
+        expect(exception).to be_kind_of(Dry::Files::UnknownMemoryNodeError)
         expect(exception.message).to eq("unknown memory node `foo'")
       end
+    end
+  end
+
+  describe "#directory?" do
+    it "is true by default" do
+      expect(subject.directory?).to be(true)
+    end
+
+    it "is false when node has a content" do
+      subject.write("foo")
+      expect(subject.directory?).to be(false)
+    end
+  end
+
+  describe "#file?" do
+    it "is false by default" do
+      expect(subject.file?).to be(false)
+    end
+
+    it "is true when node has a content" do
+      subject.write("foo")
+      expect(subject.file?).to be(true)
+    end
+  end
+
+  describe "#read" do
+    it "reads file content" do
+      subject.write("foo")
+      expect(subject.read).to eq("foo")
+    end
+
+    it "raises error when not file" do
+      expect { subject.read }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::NotMemoryFileError)
+        expect(exception.message).to eq("not a memory file `#{path}'")
+      end
+    end
+  end
+
+  describe "#readlines" do
+    it "reads file content" do
+      subject.write("foo")
+      expect(subject.readlines).to eq(["foo"])
+
+      subject.write(%w[foo bar])
+      expect(subject.readlines).to eq(["foo#{newline}", "bar"])
+    end
+
+    it "raises error when not file" do
+      expect { subject.readlines }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::NotMemoryFileError)
+        expect(exception.message).to eq("not a memory file `#{path}'")
+      end
+    end
+  end
+
+  describe "#write" do
+    it "sets file content" do
+      subject.write("foo")
+      expect(subject.read).to eq("foo")
+
+      subject.write(%w[foo bar])
+      expect(subject.read).to eq("foo#{newline}bar")
+    end
+
+    it "sets file mode" do
+      subject.write("foo")
+      expected = 0b110100100 # 0644
+
+      expect(subject.mode).to eq(expected)
+    end
+  end
+
+  describe "#chmod=" do
+    it "sets file mode (base 2)" do
+      expected = 0b001000000 # 0100
+
+      subject.chmod = expected
+      expect(subject.mode).to eq(expected)
+    end
+
+    it "sets file mode (base 8)" do
+      expected = 0b001000000 # 0100
+
+      subject.chmod = 0o100
+      expect(subject.mode).to eq(expected)
+    end
+
+    it "sets file mode (base 10)" do
+      expected = 0b001000000 # 0100
+
+      subject.chmod = 64
+      expect(subject.mode).to eq(expected)
+    end
+
+    it "sets file mode (base 16)" do
+      expected = 0b111101101 # 0755
+
+      subject.chmod = 0x1ed
+      expect(subject.mode).to eq(expected)
+    end
+  end
+
+  describe "#executable?" do
+    it "is true by default" do
+      # Default mode for node is directory.
+      # By default, UNIX directories are executable.
+      expect(subject.executable?).to be(true)
+    end
+
+    it "is false when file" do
+      subject.write("foo")
+      expect(subject.executable?).to be(false)
+    end
+
+    it "is true when executable for user" do
+      subject.chmod = 0o744
+      expect(subject.executable?).to be(true)
+    end
+
+    it "is false when not executable for user" do
+      subject.chmod = 0o474 # executable for group
+      expect(subject.executable?).to be(false)
+
+      subject.chmod = 0o447 # executable for others
+      expect(subject.executable?).to be(false)
     end
   end
 end

--- a/spec/unit/dry/files/memory_file_system_spec.rb
+++ b/spec/unit/dry/files/memory_file_system_spec.rb
@@ -1,0 +1,516 @@
+# frozen_string_literal: true
+
+require "dry/files/memory_file_system"
+require "English"
+
+RSpec.describe Dry::Files::MemoryFileSystem do
+  let(:newline) { $INPUT_RECORD_SEPARATOR }
+
+  describe "#touch" do
+    it "creates an empty file" do
+      path = subject.join("touch")
+      subject.touch(path)
+
+      expect(path).to be_found
+      expect(path).to have_file_contents("")
+    end
+
+    it "creates intermediate directories" do
+      path = subject.join("path", "to", "file", "touch")
+      subject.touch(path)
+
+      expect(path).to be_found
+      expect(path).to have_file_contents("")
+    end
+
+    it "leaves untouched existing file" do
+      path = subject.join("touch")
+      subject.write(path, "foo")
+      subject.touch(path)
+
+      expect(path).to be_found
+      expect(path).to have_file_contents("foo")
+    end
+
+    it "raises error if path is a directory" do
+      path = subject.join("touch-directory")
+      subject.mkdir(path)
+
+      expect { subject.touch(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::EISDIR)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+  end
+
+  describe "#read" do
+    it "reads file" do
+      path = subject.join("read")
+      subject.write(path, expected = "Hello#{newline}World")
+
+      expect(subject.read(path)).to eq(expected)
+    end
+
+    it "raises error when path is a directory" do
+      path = subject.join("read-directory")
+      subject.mkdir(path)
+
+      expect { subject.read(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::EISDIR)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+
+    it "raises error when path doesn't exist" do
+      path = subject.join("read-does-not-exist")
+
+      expect { subject.read(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+  end
+
+  describe "#write" do
+    it "creates an file with given contents" do
+      path = subject.join("write")
+      subject.write(path, "Hello#{newline}World")
+
+      expect(path).to be_found
+      expect(path).to have_file_contents("Hello#{newline}World")
+    end
+
+    it "creates intermediate directories" do
+      path = subject.join("path", "to", "file", "write")
+      subject.write(path, ":)")
+
+      expect(path).to be_found
+      expect(path).to have_file_contents(":)")
+    end
+
+    it "overwrites file when it already exist" do
+      path = subject.join("write")
+      subject.write(path, "many many many many words")
+      subject.write(path, "new words")
+
+      expect(path).to be_found
+      expect(path).to have_file_contents("new words")
+    end
+
+    xit "raises error when path isn't writeable" do
+      path = subject.join("write-not-writeable")
+      path.mkpath
+      mode = path.stat.mode
+
+      begin
+        path.chmod(0o000)
+
+        expect { subject.write(path.join("file-not-writeable"), "content") }.to raise_error do |exception|
+          expect(exception).to be_kind_of(Dry::Files::IOError)
+          expect(exception.cause).to be_kind_of(Errno::EACCES)
+          expect(exception.message).to include(path.to_s)
+        end
+      ensure
+        path.chmod(mode)
+      end
+    end
+  end
+
+  describe "#cp" do
+    let(:source) { subject.join("..", "source") }
+
+    before do
+      subject.rm(source) if subject.exist?(source)
+    end
+
+    it "creates a file with given contents" do
+      subject.write(source, "the source")
+
+      destination = subject.join("cp")
+      subject.cp(source, destination)
+
+      expect(destination).to be_found
+      expect(destination).to have_file_contents("the source")
+    end
+
+    it "creates intermediate directories" do
+      source = subject.join("..", "source")
+      subject.write(source, "the source for intermediate directories")
+
+      destination = subject.join("cp", "destination")
+      subject.cp(source, destination)
+
+      expect(destination).to be_found
+      expect(destination).to have_file_contents("the source for intermediate directories")
+    end
+
+    it "overrides already existing file" do
+      source = subject.join("..", "source")
+      subject.write(source, "the source")
+
+      destination = subject.join("cp")
+      subject.write(destination, "the destination")
+      subject.cp(source, destination)
+
+      expect(destination).to be_found
+      expect(destination).to have_file_contents("the source")
+    end
+
+    it "raises error when source cannot be found" do
+      source = subject.join("missing-source")
+      destination = subject.join("cp")
+
+      expect { subject.cp(source, destination) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(source.to_s)
+      end
+    end
+  end
+
+  describe "#join" do
+    it "joins a single entry" do
+      path = "path"
+      expect(subject.join(path)).to eq(path)
+
+      path = Pathname.new(path)
+      expect(subject.join(path)).to eq(path.to_s)
+    end
+
+    it "joins multiple entries" do
+      path = %w[path to file]
+      expected = path.join(File::SEPARATOR)
+
+      expect(subject.join(path)).to eq(expected)
+
+      path = path.map { |p| Pathname.new(p) }
+      expect(subject.join(path)).to eq(expected)
+    end
+  end
+
+  xdescribe "#expand_path" do
+    it "expands path from current directory" do
+      path = "expand-path"
+
+      begin
+        subject.touch(path)
+
+        expect(subject.expand_path(path, subject.pwd)).to eq(File.join(Dir.pwd, path))
+      ensure
+        FileUtils.rm_rf(path)
+      end
+    end
+
+    it "expands path from current directory in combination with chdir" do
+      path = subject.join("expand-path", "dir", "file")
+      subject.touch(path)
+
+      subject.chdir(subject.join("expand-path", "dir")) do
+        expect(subject.expand_path("file")).to eq(path.realpath.to_s)
+      end
+    end
+
+    it "expands path from given directory" do
+      dir = subject.join("expand-path", "given-dir")
+      path = dir.join("file")
+      subject.touch(path)
+
+      expect(subject.expand_path("file", dir)).to eq(path.realpath.to_s)
+    end
+
+    it "returns absolute path as it is" do
+      path = subject.join("expand-path", "absolute")
+      subject.touch(path)
+
+      expect(subject.expand_path(path.realpath)).to eq(path.realpath.to_s)
+    end
+  end
+
+  describe "#pwd" do
+    it "returns root directory by default" do
+      expect(subject.pwd).to eq("/")
+    end
+  end
+
+  describe "#chdir" do
+    it "changes current working directory" do
+      current_directory = subject.pwd
+      subject.mkdir(dir = "path/to/dir")
+
+      subject.chdir(dir) do
+        expect(subject.pwd).to eq("dir")
+      end
+
+      expect(subject.pwd).to eq(current_directory)
+    end
+
+    it "raises error if directory cannot be found" do
+      path = subject.join("chdir-non-existing")
+
+      expect { subject.chdir(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+
+    it "raises error if argument is a file" do
+      path = subject.join("chdir-file")
+      subject.touch(path)
+
+      expect { subject.chdir(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOTDIR)
+        expect(exception.message).to match(path.to_s)
+      end
+    end
+  end
+
+  describe "#mkdir" do
+    it "creates directory" do
+      path = subject.join("mkdir")
+      subject.mkdir(path)
+
+      expect(subject.directory?(path)).to be(true)
+    end
+
+    it "creates intermediate directories" do
+      path = subject.join("path", "to", "mkdir")
+      subject.mkdir(path)
+
+      expect(subject.directory?(path)).to be(true)
+    end
+
+    xit "raises error when path isn't writeable" do
+      path = subject.join("mkdir-not-writeable")
+      path.mkpath
+      mode = path.stat.mode
+
+      begin
+        path.chmod(0o000)
+
+        expect { subject.mkdir(path.join("dir-not-writeable")) }.to raise_error do |exception|
+          expect(exception).to be_kind_of(Dry::Files::IOError)
+          expect(exception.cause).to be_kind_of(Errno::EACCES)
+          expect(exception.message).to include(path.to_s)
+        end
+      ensure
+        path.chmod(mode)
+      end
+    end
+  end
+
+  describe "#mkdir_p" do
+    it "creates directory" do
+      directory = subject.join("mkdir_p")
+      path = subject.join(directory, "file.rb")
+      subject.mkdir_p(path)
+
+      expect(subject.directory?(directory)).to be(true)
+      expect(path).to_not be_found
+    end
+
+    it "creates intermediate directories" do
+      directory = subject.join("path", "to", "mkdir_p")
+      path = subject.join(directory, "file.rb")
+      subject.mkdir_p(path)
+
+      expect(subject.directory?(directory)).to be(true)
+      expect(path).to_not be_found
+    end
+
+    xit "raises error when path isn't writeable" do
+      parent = subject.join("path")
+      parent.mkpath
+      mode = parent.stat.mode
+
+      begin
+        parent.chmod(0o000)
+        path = parent.join("to", "mkdir_p", "dir-not-writeable")
+
+        expect { subject.mkdir_p(path) }.to raise_error do |exception|
+          expect(exception).to be_kind_of(Dry::Files::IOError)
+          expect(exception.cause).to be_kind_of(Errno::EACCES)
+          expect(exception.message).to include(parent.to_s)
+        end
+      ensure
+        parent.chmod(mode)
+      end
+    end
+  end
+
+  describe "#rm" do
+    it "deletes path" do
+      path = subject.join("delete", "file")
+      subject.touch(path)
+      subject.rm(path)
+
+      expect(path).to_not be_found
+    end
+
+    it "raises error if path doesn't exist" do
+      path = subject.join("delete", "file")
+
+      expect { subject.rm(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+
+    it "raises error if path is a directory" do
+      path = subject.join("delete", "directory")
+      subject.mkdir(path)
+
+      expect { subject.rm(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::EPERM)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+  end
+
+  describe "#rm_rf" do
+    it "deletes directory" do
+      path = subject.join("delete", "directory")
+      subject.mkdir(path)
+      subject.rm_rf(path)
+
+      expect(path).to_not be_found
+    end
+
+    it "deletes a file" do
+      path = subject.join("delete_directory", "file")
+      subject.touch(path)
+      subject.rm_rf(path)
+
+      expect(path).to_not be_found
+    end
+
+    it "raises error if directory doesn't exist" do
+      path = subject.join("delete", "directory")
+
+      expect { subject.rm_rf(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+  end
+
+  describe "#readlines" do
+    it "reads file and returns array of lines" do
+      path = subject.join("readlines-file")
+      subject.write(path, "hello#{newline}world")
+
+      expect(subject.readlines(path)).to eq(%W[hello#{newline} world])
+    end
+
+    it "reads empty file and returns empty array" do
+      path = subject.join("readlines-empty-file")
+      subject.touch(path)
+
+      expect(subject.readlines(path)).to eq([])
+    end
+
+    it "raises error if file doesn't exist" do
+      path = subject.join("readlines-non-existing-file")
+
+      expect { subject.readlines(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+
+    it "raises error if path is a directory" do
+      path = subject.join("readlines", "directory")
+      subject.mkdir(path)
+
+      expect { subject.readlines(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::EISDIR)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+
+    xit "it raises error if path isn't readable"
+  end
+
+  describe "#exist?" do
+    it "returns true for file" do
+      path = subject.join("exist-file")
+      subject.touch(path)
+
+      expect(subject.exist?(path)).to be(true)
+    end
+
+    it "returns true for directory" do
+      path = subject.join("exist-dir")
+      subject.mkdir(path)
+
+      expect(subject.exist?(path)).to be(true)
+    end
+
+    it "returns false for non-existing file" do
+      path = subject.join("exist-non-existing")
+
+      expect(subject.exist?(path)).to be(false)
+    end
+  end
+
+  describe "#directory?" do
+    it "returns true for directory" do
+      path = subject.join("directory-dir")
+      subject.mkdir(path)
+
+      expect(subject.directory?(path)).to be(true)
+    end
+
+    it "returns false for file" do
+      path = subject.join("directory-file")
+      subject.touch(path)
+
+      expect(subject.directory?(path)).to be(false)
+    end
+
+    it "returns false for non-existing path" do
+      path = subject.join("directory-non-existing")
+
+      expect(subject.directory?(path)).to be(false)
+    end
+  end
+
+  xdescribe "#executable?" do
+    it "returns true when file is executable" do
+      path = subject.join("executable-exec")
+      subject.touch(path)
+      path.chmod(0o744)
+
+      expect(subject.executable?(path)).to be(true)
+    end
+
+    it "returns false when file isn't executable" do
+      path = subject.join("executable-non-exec")
+      subject.touch(path)
+
+      expect(subject.executable?(path)).to be(false)
+    end
+
+    it "returns false when file doesn't exist" do
+      path = subject.join("executable-non-existing")
+
+      expect(subject.executable?(path)).to be(false)
+    end
+
+    it "returns true for directory" do
+      path = subject.join("executable-directory")
+      subject.mkdir(path)
+
+      expect(subject.executable?(path)).to be(true)
+    end
+  end
+end

--- a/spec/unit/dry/files/memory_file_system_spec.rb
+++ b/spec/unit/dry/files/memory_file_system_spec.rb
@@ -484,11 +484,11 @@ RSpec.describe Dry::Files::MemoryFileSystem do
     end
   end
 
-  xdescribe "#executable?" do
+  describe "#executable?" do
     it "returns true when file is executable" do
       path = subject.join("executable-exec")
       subject.touch(path)
-      path.chmod(0o744)
+      subject.chmod(path, 0o744)
 
       expect(subject.executable?(path)).to be(true)
     end

--- a/spec/unit/dry/files/path_spec.rb
+++ b/spec/unit/dry/files/path_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "dry/files/path"
+
+RSpec.describe Dry::Files::Path do
+  describe ".call" do
+    let(:unix_file_separator) { "/" }
+    let(:windows_file_separator) { '\\' }
+
+    context "when string" do
+      it "recombines given path with system file separator" do
+        tokens = %w[path to file]
+        expected = tokens.join(::File::SEPARATOR)
+
+        expect(described_class.call(tokens.join(unix_file_separator))).to eq(expected)
+        expect(described_class.call(tokens.join(windows_file_separator))).to eq(expected)
+      end
+    end
+
+    context "when array" do
+      it "recombines given path with system file separator" do
+        tokens = %w[path to file]
+        expected = tokens.join(::File::SEPARATOR)
+
+        expect(described_class.call(tokens)).to eq(expected)
+      end
+    end
+
+    context "when splat arguments" do
+      it "recombines given path with system file separator" do
+        tokens = ["path", %w[to file]]
+        expected = tokens.flatten.join(::File::SEPARATOR)
+
+        expect(described_class.call(*tokens)).to eq(expected)
+      end
+    end
+  end
+
+  describe ".[]" do
+    it "is a .call alias" do
+      path = "path/to/file"
+
+      expect(described_class[path]).to eq(described_class.call(path))
+    end
+  end
+
+  describe ".split" do
+    it "splits path according to the current OS directory separator" do
+      expected = %w[path to file]
+      path = expected.join(::File::SEPARATOR)
+
+      expect(described_class.split(path)).to eq(expected)
+    end
+  end
+end

--- a/spec/unit/dry/files/path_spec.rb
+++ b/spec/unit/dry/files/path_spec.rb
@@ -52,10 +52,23 @@ RSpec.describe Dry::Files::Path do
       expect(described_class.split(path)).to eq(expected)
     end
 
-    it "returns empty token when path equals to `#{::File::SEPARATOR}'" do
+    it "returns empty token when path equals to current OS directory separator" do
       path = ::File::SEPARATOR
 
       expect(described_class.split(path)).to eq("")
+    end
+  end
+
+  describe ".absolute?" do
+    it "returns true when path starts with current OS directory separator" do
+      separator = ::File::SEPARATOR
+
+      expect(described_class.absolute?(separator)).to be(true)
+      expect(described_class.absolute?("#{separator}foo")).to be(true)
+    end
+
+    it "returns false when path starts with any other token" do
+      expect(described_class.absolute?("foo")).to be(false)
     end
   end
 end

--- a/spec/unit/dry/files/path_spec.rb
+++ b/spec/unit/dry/files/path_spec.rb
@@ -71,4 +71,17 @@ RSpec.describe Dry::Files::Path do
       expect(described_class.absolute?("foo")).to be(false)
     end
   end
+
+  describe ".dirname" do
+    it "returns directory name for given path" do
+      path = ::File::SEPARATOR
+      expect(described_class.dirname(path)).to eq(::File::SEPARATOR)
+
+      path = "#{::File::SEPARATOR}foo"
+      expect(described_class.dirname(path)).to eq(::File::SEPARATOR)
+
+      path = "#{::File::SEPARATOR}#{%w[foo bar].join(::File::SEPARATOR)}"
+      expect(described_class.dirname(path)).to eq("#{::File::SEPARATOR}foo")
+    end
+  end
 end

--- a/spec/unit/dry/files/path_spec.rb
+++ b/spec/unit/dry/files/path_spec.rb
@@ -51,5 +51,11 @@ RSpec.describe Dry::Files::Path do
 
       expect(described_class.split(path)).to eq(expected)
     end
+
+    it "returns empty token when path equals to `#{::File::SEPARATOR}'" do
+      path = ::File::SEPARATOR
+
+      expect(described_class.split(path)).to eq("")
+    end
   end
 end

--- a/spec/unit/dry/files/version_spec.rb
+++ b/spec/unit/dry/files/version_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe "Dry::Files::VERSION" do
+  it "exposes version" do
+    expect(Dry::Files::VERSION).to eq("0.1.0")
+  end
+end


### PR DESCRIPTION
## Enhancements

  * Introduced adapter concept
  * The gem ships with two adapters: file system (default), and in-memory file system
  * File system adapter is designed for production and integration tests
  * In memory adapter is designed for unit tests
  * In memory adapter is ephemeral
  * In memory adapter is **experimental**
  * These adapters have a parity of features and almost all the behavior is similar
  * API docs, cleanup, specs

```ruby
# frozen_string_literal: true

require "dry/files"

Dry::Files.new # uses default adapter: file system
Dry::Files.new(memory: true) # uses in-memory adapter
```