### PR TITLE
Chomp lines for readline

### DIFF
--- a/lib/dry/files/memory_file_system/node.rb
+++ b/lib/dry/files/memory_file_system/node.rb
@@ -203,7 +203,7 @@ module Dry
           raise NotMemoryFileError, segment unless file?
 
           @content.rewind
-          @content.readlines
+          @content.readlines(chomp: true)
         end
 
         # Write file contents

--- a/spec/unit/dry/files/memory_file_system/node_spec.rb
+++ b/spec/unit/dry/files/memory_file_system/node_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Dry::Files::MemoryFileSystem::Node do
       expect(subject.readlines).to eq(["foo"])
 
       subject.write(%w[foo bar])
-      expect(subject.readlines).to eq(["foo#{newline}", "bar"])
+      expect(subject.readlines).to eq(["foo", "bar"])
     end
 
     it "raises error when not file" do


### PR DESCRIPTION
This is so when they're read out, they do not contain line breaks at the end of each line's string. Later on, when this content is passed to write, it is joined with , which will add newlines.

I think this will probably fix the issue @solnic was seeing with these failing specs: https://github.com/hanami/cli/commit/755f7d27235afa74c1ffc49ce10e85ce6bf168f8