### PR TITLE
Expose public #open method

### DIFF
--- a/lib/dry/files.rb
+++ b/lib/dry/files.rb
@@ -14,6 +14,14 @@ module Dry
     require_relative "files/error"
     require_relative "files/adapter"
 
+    # @since 0.3.0
+    # @api public
+    OPEN_MODE = ::File::RDWR
+
+    # @since 0.3.0
+    # @api public
+    WRITE_MODE = (::File::CREAT | ::File::WRONLY | ::File::TRUNC).freeze
+
     # Creates a new instance
     #
     # Memory file system is experimental
@@ -109,6 +117,22 @@ module Dry
     # @since 0.1.0
     def pwd
       adapter.pwd
+    end
+
+    # Opens (or creates) a new file for both read/write operations
+    #
+    # @param path [String] the target file
+    # @param mode [String,Integer] Ruby file open mode
+    # @param args [Array<Object>] ::File.open args
+    # @param blk [Proc] the block to yield
+    #
+    # @yieldparam [File,Dry::Files::MemoryFileSystem::Node] the opened file
+    #
+    # @return [File,Dry::Files::MemoryFileSystem::Node] the opened file
+    #
+    # @raise [Dry::Files::IOError] in case of I/O error
+    def open(path, mode = OPEN_MODE, *args, &blk)
+      adapter.open(path, mode, *args, &blk)
     end
 
     # Temporary changes the current working directory of the process to the

--- a/lib/dry/files/file_system.rb
+++ b/lib/dry/files/file_system.rb
@@ -46,7 +46,7 @@ module Dry
       # @raise [Dry::Files::IOError] in case of I/O error
       #
       # @since 0.1.0
-      def open(path, mode = OPEN_MODE, *args, &blk)
+      def open(path, mode, *args, &blk)
         touch(path)
 
         with_error_handling do
@@ -344,16 +344,6 @@ module Dry
       end
 
       private
-
-      # @since 0.1.0
-      # @api private
-      OPEN_MODE = ::File::RDWR
-      private_constant :OPEN_MODE
-
-      # @since 0.1.0
-      # @api private
-      WRITE_MODE = (::File::CREAT | ::File::WRONLY | ::File::TRUNC).freeze
-      private_constant :WRITE_MODE
 
       # Catch `SystemCallError` and re-raise a `Dry::Files::IOError`.
       #

--- a/lib/dry/files/memory_file_system.rb
+++ b/lib/dry/files/memory_file_system.rb
@@ -33,12 +33,18 @@ module Dry
       #
       # @param path [String] the target file
       # @yieldparam [Dry::Files::MemoryFileSystem::Node]
+      # @return [Dry::Files::MemoryFileSystem::Node]
       #
       # @since 0.1.0
       # @api private
-      def open(path, *, &blk)
+      def open(path, *)
         file = touch(path)
-        blk.call(file)
+
+        if block_given?
+          yield file
+        else
+          file
+        end
       end
 
       # Read file contents

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require_relative "support/coverage"
 
 $LOAD_PATH.unshift "lib"
 require "dry/files"
+require "pathname"
 require_relative "./support/rspec"
 
 %w[support].each do |dir|

--- a/spec/unit/dry/files/file_system_spec.rb
+++ b/spec/unit/dry/files/file_system_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Dry::Files::FileSystem do
         path = root.join("open-not-exist")
         content = "foo"
 
-        subject.open(path) do |file|
+        subject.open(path, Dry::Files::OPEN_MODE) do |file|
           expect(file).to be_kind_of(::File)
           expect(file.read).to eq("")
 
@@ -40,7 +40,7 @@ RSpec.describe Dry::Files::FileSystem do
         path = root.join("open-exist")
         subject.write(path, content = "foo")
 
-        subject.open(path) do |file|
+        subject.open(path, Dry::Files::OPEN_MODE) do |file|
           expect(file).to be_kind_of(::File)
           expect(file.read).to eq(content)
 
@@ -48,6 +48,23 @@ RSpec.describe Dry::Files::FileSystem do
         end
 
         expect(path).to have_content(content * 2)
+      end
+    end
+
+    context "when no block is given" do
+      it "returns the open file object" do
+        path = root.join("open-exist")
+        subject.write(path, content = "foo")
+
+        file = subject.open(path, Dry::Files::OPEN_MODE)
+        expect(file).to be_kind_of(::File)
+        expect(file.read).to eq(content)
+
+        file.write(content)
+        file.rewind
+        expect(path).to have_content(content * 2)
+      ensure
+        file.close
       end
     end
   end

--- a/spec/unit/dry/files/memory_file_system_spec.rb
+++ b/spec/unit/dry/files/memory_file_system_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Dry::Files::MemoryFileSystem do
       it "creates file with empty content and yields node" do
         path = subject.join("open-new")
 
-        subject.open(path) do |file|
+        subject.open(path, Dry::Files::OPEN_MODE) do |file|
           expect(file).to be_kind_of(Dry::Files::MemoryFileSystem::Node)
         end
 
@@ -30,11 +30,22 @@ RSpec.describe Dry::Files::MemoryFileSystem do
         path = subject.join("open-non-existing")
         subject.write("open-non-existing", content = "foo")
 
-        subject.open(path) do |file|
+        subject.open(path, Dry::Files::OPEN_MODE) do |file|
           expect(file).to be_kind_of(Dry::Files::MemoryFileSystem::Node)
         end
 
         expect(path).to have_file_contents(content)
+      end
+    end
+
+    context "when no block is given" do
+      it "returns the open file object" do
+        path = subject.join("open-new")
+
+        file = subject.open(path, Dry::Files::OPEN_MODE)
+        expect(file).to be_kind_of(Dry::Files::MemoryFileSystem::Node)
+
+        expect(path).to have_file_contents("")
       end
     end
   end


### PR DESCRIPTION
There is currently no way to get a persistent file handle from the public interface. 

You sometimes want to do this, e.g. for defining a log device. It would be nice to test log output without writing to the actual FS. I've worked around this by making `StringIO` injectable through configuration, but that's an annoying special case and using a virtual FS during test would be really convenient.

When a block is not passed to File.open, it returns the open file instance. `MemoryFileSystem` was not doing this, making the interfaces inconsistent.

I'm unsure if this should be specifically documented; basically this makes `#open` work like `File.open` so it should not be surprising, but also it is somewhat problematic since you have to clean up the file handle manually.