### PR TITLE
`Dry::Files#inject_line_at_block_bottom` to handle nested Ruby blocks

### DIFF
--- a/lib/dry/files.rb
+++ b/lib/dry/files.rb
@@ -785,30 +785,41 @@ module Dry
     SPACE_MATCHER = /\A[[:space:]]*/.freeze
     private_constant :SPACE_MATCHER
 
-    # @since 0.1.0
+    # @since 0.3.0
     # @api private
-    INLINE_OPEN_BLOCK_MATCHER = "{"
-    private_constant :INLINE_OPEN_BLOCK_MATCHER
+    INLINE_OPEN_BLOCK = "{"
+    private_constant :INLINE_OPEN_BLOCK
 
     # @since 0.1.0
     # @api private
     INLINE_CLOSE_BLOCK = "}"
     private_constant :INLINE_CLOSE_BLOCK
 
+    # @since 0.3.0
+    # @api private
+    OPEN_BLOCK = "do"
+    private_constant :OPEN_BLOCK
+
     # @since 0.1.0
     # @api private
     CLOSE_BLOCK = "end"
     private_constant :CLOSE_BLOCK
 
-    # @since 0.3.0
+    # @since 0.1.0
     # @api private
-    BLOCK_DELIMITER = Delimiter.new("BlockDelimiter", "do", "end")
-    private_constant :BLOCK_DELIMITER
+    INLINE_OPEN_BLOCK_MATCHER = INLINE_CLOSE_BLOCK
+    private_constant :INLINE_OPEN_BLOCK_MATCHER
 
     # @since 0.3.0
     # @api private
-    INLINE_BLOCK_DELIMITER = Delimiter.new("InlineBlockDelimiter", "{", "}")
+    INLINE_BLOCK_DELIMITER = Delimiter.new("InlineBlockDelimiter",
+                                           INLINE_OPEN_BLOCK, INLINE_CLOSE_BLOCK)
     private_constant :INLINE_BLOCK_DELIMITER
+
+    # @since 0.3.0
+    # @api private
+    BLOCK_DELIMITER = Delimiter.new("BlockDelimiter", OPEN_BLOCK, CLOSE_BLOCK)
+    private_constant :BLOCK_DELIMITER
 
     # @since 0.1.0
     # @api private

--- a/spec/integration/dry/files_spec.rb
+++ b/spec/integration/dry/files_spec.rb
@@ -1400,6 +1400,41 @@ RSpec.describe Dry::Files do
       expect(path).to have_content(expected)
     end
 
+    it "injects block at the bottom of the nested Ruby block" do
+      path = root.join("inject_block_at_nested_block_bottom.rb")
+      content = <<~CONTENT
+        class Routes
+          define do
+            slice :foo, at: "/foo" do
+            end
+          end
+        end
+      CONTENT
+
+      block = <<~BLOCK
+
+        slice :bar, at: "/bar" do
+        end
+      BLOCK
+
+      subject.write(path, content)
+      subject.inject_line_at_block_bottom(path, "define", block)
+
+      expected = <<~CONTENT
+        class Routes
+          define do
+            slice :foo, at: "/foo" do
+            end
+
+            slice :bar, at: "/bar" do
+            end
+          end
+        end
+      CONTENT
+
+      expect(path).to have_content(expected)
+    end
+
     it "raises error if file cannot be found" do
       path = root.join("inject_line_at_block_bottom_missing_file.rb")
 

--- a/spec/integration/dry/files_spec.rb
+++ b/spec/integration/dry/files_spec.rb
@@ -1263,6 +1263,43 @@ RSpec.describe Dry::Files do
       expect(path).to have_content(expected)
     end
 
+    it "injects block at the top of the nested Ruby block" do
+      path = root.join("inject_block_at_nested_block_top.rb")
+      content = <<~CONTENT
+        class InjectBlockBlockTop
+          configure do
+            routes do
+              resources :books do
+                get "/discounted", to: "books.discounted"
+              end
+            end
+          end
+        end
+      CONTENT
+
+      block = <<~BLOCK
+        root { "Hello" }
+      BLOCK
+
+      subject.write(path, content)
+      subject.inject_line_at_block_top(path, "routes", block)
+
+      expected = <<~CONTENT
+        class InjectBlockBlockTop
+          configure do
+            routes do
+              root { "Hello" }
+              resources :books do
+                get "/discounted", to: "books.discounted"
+              end
+            end
+          end
+        end
+      CONTENT
+
+      expect(path).to have_content(expected)
+    end
+
     it "raises error if file cannot be found" do
       path = root.join("inject_line_at_block_top_missing_file.rb")
 

--- a/spec/integration/dry/files_spec.rb
+++ b/spec/integration/dry/files_spec.rb
@@ -1405,28 +1405,42 @@ RSpec.describe Dry::Files do
       content = <<~CONTENT
         class Routes
           define do
+            root { "Hello" }
+
             slice :foo, at: "/foo" do
             end
           end
         end
       CONTENT
 
-      block = <<~BLOCK
+      block_one = <<~BLOCK
 
         slice :bar, at: "/bar" do
         end
       BLOCK
 
+      block_two = <<~BLOCK
+
+        slice :baz, at: "/baz" do
+        end
+      BLOCK
+
       subject.write(path, content)
-      subject.inject_line_at_block_bottom(path, "define", block)
+      subject.inject_line_at_block_bottom(path, "define", block_one)
+      subject.inject_line_at_block_bottom(path, "define", block_two)
 
       expected = <<~CONTENT
         class Routes
           define do
+            root { "Hello" }
+
             slice :foo, at: "/foo" do
             end
 
             slice :bar, at: "/bar" do
+            end
+
+            slice :baz, at: "/baz" do
             end
           end
         end


### PR DESCRIPTION
# Bug

Invoking many times `Dry::Files#inject_line_at_block_bottom` to inject a Ruby block, the method was targeting the wrong block.

Here's an example with Hanami.
By generating many slices, it was keep nesting slice inside another slice block, etc...

## Before

```ruby
# frozen_string_literal: true

require "hanami/routes"

module Bookshelf
  class Routes < Hanami::Routes
    define do
      root { "Hello from Hanami" }
      
      slice :admin, at: "/admin" do
        
        slice :billing, at: "/billing" do
          
          slice :api, at: "/api" do
          end
        end
      end
    end
  end
end
```

## After

It targets the intended Ruby block, avoiding unwanted block nesting:

```ruby
# frozen_string_literal: true

require "hanami/routes"

module Bookshelf
  class Routes < Hanami::Routes
    define do
      root { "Hello from Hanami" }

      slice :admin, at: "/admin" do
      end

      slice :billing, at: "/billing" do
      end

      slice :api, at: "/api" do
      end
    end
  end
end
```