### PR TITLE
Ensure `Dry::Files#write` with memory adapter to avoid extra newlines

### DIFF
--- a/lib/dry/files.rb
+++ b/lib/dry/files.rb
@@ -762,6 +762,11 @@ module Dry
 
     # @since 0.3.0
     # @api private
+    NEW_LINE_MATCHER = /#{NEW_LINE}\z/.freeze
+    private_constant :NEW_LINE_MATCHER
+
+    # @since 0.3.0
+    # @api private
     EMPTY_LINE = /\A\z/.freeze
     private_constant :EMPTY_LINE
 

--- a/lib/dry/files/memory_file_system.rb
+++ b/lib/dry/files/memory_file_system.rb
@@ -11,7 +11,7 @@ module Dry
     class MemoryFileSystem
       # @since 0.1.0
       # @api private
-      EMPTY_CONTENT = nil
+      EMPTY_CONTENT = ""
       private_constant :EMPTY_CONTENT
 
       require_relative "./memory_file_system/node"

--- a/lib/dry/files/memory_file_system/node.rb
+++ b/lib/dry/files/memory_file_system/node.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "English"
 require "stringio"
 
 module Dry
@@ -215,8 +214,17 @@ module Dry
         #
         # @since 0.1.0
         # @api private
-        def write(*content)
-          @content = StringIO.new(content.join($RS))
+        def write(content)
+          content = case content
+                    when String
+                      content
+                    when Array
+                      array_to_string(content)
+                    when NilClass
+                      EMPTY_CONTENT
+                    end
+
+          @content = StringIO.new(content)
           @mode = DEFAULT_FILE_MODE
         end
 
@@ -239,6 +247,14 @@ module Dry
         # @api private
         def executable?
           (mode & MODE_USER_EXECUTE).positive?
+        end
+
+        # @since 0.3.0
+        # @api private
+        def array_to_string(content)
+          content.map do |line|
+            line.sub(NEW_LINE_MATCHER, EMPTY_CONTENT)
+          end.join(NEW_LINE) + NEW_LINE
         end
       end
     end

--- a/spec/unit/dry/files/memory_file_system/node_spec.rb
+++ b/spec/unit/dry/files/memory_file_system/node_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Dry::Files::MemoryFileSystem::Node do
       expect(subject.readlines).to eq(["foo"])
 
       subject.write(%w[foo bar])
-      expect(subject.readlines).to eq(["foo#{newline}", "bar"])
+      expect(subject.readlines).to eq(["foo#{newline}", "bar#{newline}"])
     end
 
     it "raises error when not file" do
@@ -162,7 +162,7 @@ RSpec.describe Dry::Files::MemoryFileSystem::Node do
       expect(subject.read).to eq("foo")
 
       subject.write(%w[foo bar])
-      expect(subject.read).to eq("foo#{newline}bar")
+      expect(subject.read).to eq("foo#{newline}bar#{newline}")
     end
 
     it "sets file mode" do

--- a/spec/unit/dry/files/memory_file_system_spec.rb
+++ b/spec/unit/dry/files/memory_file_system_spec.rb
@@ -147,12 +147,33 @@ RSpec.describe Dry::Files::MemoryFileSystem do
   end
 
   describe "#write" do
-    it "creates an file with given contents" do
+    it "creates an file with given contents (string)" do
       path = subject.join("write")
       subject.write(path, "Hello#{newline}World")
 
       expect(path).to be_found
       expect(path).to have_file_contents("Hello#{newline}World")
+    end
+
+    it "creates an file with given contents (array)" do
+      path = subject.join("write")
+      content = ["# frozen_string_literal: true#{newline}", newline, "module Foo#{newline}", "  class App#{newline}", "    CONSTANT = 23#{newline}", newline, "    def call(*)#{newline}", "    end#{newline}", "  end#{newline}", "end#{newline}"]
+      expected = <<~CONTENT
+        # frozen_string_literal: true
+
+        module Foo
+          class App
+            CONSTANT = 23
+
+            def call(*)
+            end
+          end
+        end
+      CONTENT
+      subject.write(path, content)
+
+      expect(path).to be_found
+      expect(path).to have_file_contents(expected)
     end
 
     it "creates intermediate directories" do


### PR DESCRIPTION
# Bug

Memory adapter was creating extra new lines when `Dry::Files#write` was used.

## Before

```ruby
# frozen_string_literal: true



module Foo

    class App

      CONSTANT = 23



      def call(*)

      end

    end

end
```

## After

```ruby
# frozen_string_literal: true

module Foo
  class App
    CONSTANT = 23

    def call(*)
    end
  end
end
```