### PR TITLE
Ensure `Dry::Files#inject_line_at_block_bottom` is able to target the right deeply nested Ruby block

### DIFF
--- a/lib/dry/files.rb
+++ b/lib/dry/files.rb
@@ -665,7 +665,8 @@ module Dry
                   else
                     BLOCK_DELIMITER
                   end
-      ending    = closing_block_index(content, path, line, delimiter)
+      target    = content[starting..]
+      ending    = closing_block_index(target, starting, path, line, delimiter)
       offset    = SPACE * (content[ending][SPACE_MATCHER].bytesize + INDENTATION)
 
       contents = Array(contents).flatten
@@ -864,15 +865,15 @@ module Dry
 
     # @since 0.3.0
     # @api private
-    def closing_block_index(content, path, target, delimiter)
+    def closing_block_index(content, starting, path, target, delimiter)
       blocks_count = content.count { |line| line.match?(delimiter.opening) }
       matching_line = content.find do |line|
         blocks_count -= 1 if line.match?(delimiter.closing)
         line if blocks_count.zero?
       end
 
-      content.index(matching_line) or
-        raise MissingTargetError.new(target, path)
+      (content.index(matching_line) or
+        raise MissingTargetError.new(target, path)) + starting
     end
 
     # @since 0.1.0

--- a/spec/integration/dry/files_spec.rb
+++ b/spec/integration/dry/files_spec.rb
@@ -1486,6 +1486,41 @@ RSpec.describe Dry::Files do
       expect(path).to have_content(expected)
     end
 
+    it "injects block at the bottom of the deeply nested Ruby block" do
+      path = root.join("inject_block_at_deeply_nested_block_bottom.rb")
+      content = <<~CONTENT
+        class Routes
+          define do
+            root { "Hello" }
+
+            slice :foo, at: "/foo" do
+            end
+          end
+        end
+      CONTENT
+
+      input = <<~BLOCK
+        get "/users", to: "users.index"
+      BLOCK
+
+      subject.write(path, content)
+      subject.inject_line_at_block_bottom(path, "slice :foo", input)
+
+      expected = <<~CONTENT
+        class Routes
+          define do
+            root { "Hello" }
+
+            slice :foo, at: "/foo" do
+              get "/users", to: "users.index"
+            end
+          end
+        end
+      CONTENT
+
+      expect(path).to have_content(expected)
+    end
+
     it "raises error if file cannot be found" do
       path = root.join("inject_line_at_block_bottom_missing_file.rb")
 


### PR DESCRIPTION
Follow up of https://github.com/dry-rb/dry-files/pull/10