### PR TITLE
Avoid double newlines when appending to a file

### DIFF
--- a/lib/dry/files.rb
+++ b/lib/dry/files.rb
@@ -933,6 +933,8 @@ module Dry
     # @since 0.1.0
     # @api private
     def newline(line = nil)
+      return line if line.to_s.end_with?(NEW_LINE)
+
       "#{line}#{NEW_LINE}"
     end
 

--- a/spec/integration/dry/files_spec.rb
+++ b/spec/integration/dry/files_spec.rb
@@ -494,10 +494,26 @@ RSpec.describe Dry::Files do
       expect(path).to have_content(expected)
     end
 
-    # This gem was originally extracted from hanami-utils, into dry-cli,
-    # and finally into dry-files.
-    #
-    # https://github.com/hanami/utils/issues/348
+    it "does not add multiple newlines to the bottom of the file" do
+      path = root.join("append.rb")
+      content = <<~CONTENT
+        class Append
+        end
+      CONTENT
+
+      subject.write(path, content)
+      subject.append(path, "#{newline}Foo.register Append\n")
+
+      expected = <<~CONTENT
+        class Append
+        end
+
+        Foo.register Append
+      CONTENT
+
+      expect(path).to have_content(expected)
+    end
+
     it "adds a line at the bottom of a file that doesn't end with a newline" do
       path = root.join("append_missing_newline.rb")
       content = "root to: 'home#index'"


### PR DESCRIPTION
With this change, we generate a nice looking `Gemfile` in apps generated with `hanami new`:

```
# frozen_string_literal: true

source "https://rubygems.org"

gem "hanami", "~> 2.0"
gem "hanami-router", "~> 2.0"
gem "hanami-controller", "~> 2.0"
gem "hanami-validations", "~> 2.0"

gem "dry-types", "~> 1.0", ">= 1.6.1"
gem "puma"
gem "rake"

group :development, :test do
  gem "dotenv"
end

group :cli, :development do
  gem "hanami-reloader"
end

group :cli, :development, :test do
  gem "hanami-rspec"
end

group :development do
  gem "guard-puma", "~> 0.8"
end

group :test do
  gem "rack-test"
end
```

Without this change, we end up generating a `Gemfile` with multiple spurious newlines.

```
# frozen_string_literal: true

source "https://rubygems.org"

gem "hanami", "~> 2.0"
gem "hanami-router", "~> 2.0"
gem "hanami-controller", "~> 2.0"
gem "hanami-validations", "~> 2.0"

gem "dry-types", "~> 1.0", ">= 1.6.1"
gem "puma"
gem "rake"

group :development, :test do
  gem "dotenv"
end

group :cli, :development do
  gem "hanami-reloader"
end

group :cli, :development, :test do
  gem "hanami-rspec"
end

group :development do
  gem "guard-puma", "~> 0.8"
end


group :test do
  gem "rack-test"
end

```

I'd like to get this out in a patch release in the next ~day, before the Hanami release.