### PR TITLE
Ensure `Dry::Files#inject_line_at_block_bottom` to not match false positive closing blocks

### DIFF
--- a/lib/dry/files.rb
+++ b/lib/dry/files.rb
@@ -844,8 +844,8 @@ module Dry
       # @since 1.0.2
       # @api private
       SPACE_MATCHER_GENERAL = /[[:space:]]*/
-
       private_constant :SPACE_MATCHER_GENERAL
+
       # @since 0.3.0
       # @api private
       attr_reader :opening, :closing

--- a/lib/dry/files.rb
+++ b/lib/dry/files.rb
@@ -841,6 +841,11 @@ module Dry
     # @since 0.3.0
     # @api private
     class Delimiter
+      # @since 1.0.2
+      # @api private
+      SPACE_MATCHER_GENERAL = /[[:space:]]*/
+
+      private_constant :SPACE_MATCHER_GENERAL
       # @since 0.3.0
       # @api private
       attr_reader :opening, :closing
@@ -852,6 +857,26 @@ module Dry
         @opening = opening
         @closing = closing
         freeze
+      end
+
+      # @since 1.0.2
+      # @api private
+      def opening_matcher
+        matcher(opening)
+      end
+
+      # @since 1.0.2
+      # @api private
+      def closing_matcher
+        matcher(closing)
+      end
+
+      private
+
+      # @since 1.0.2
+      # @api private
+      def matcher(delimiter)
+        /#{SPACE_MATCHER_GENERAL}\b#{delimiter}\b(?:#{SPACE_MATCHER_GENERAL}|#{NEW_LINE_MATCHER})/
       end
     end
 
@@ -967,9 +992,9 @@ module Dry
     # @since 0.3.0
     # @api private
     def closing_block_index(content, starting, path, target, delimiter, count_offset = 0) # rubocop:disable Metrics/ParameterLists
-      blocks_count = content.count { |line| line.match?(delimiter.opening) } + count_offset
+      blocks_count = content.count { |line| line.match?(delimiter.opening_matcher) } + count_offset
       matching_line = content.find do |line|
-        blocks_count -= 1 if line.match?(delimiter.closing)
+        blocks_count -= 1 if line.match?(delimiter.closing_matcher)
         line if blocks_count.zero?
       end
 

--- a/spec/integration/dry/files_spec.rb
+++ b/spec/integration/dry/files_spec.rb
@@ -1369,6 +1369,59 @@ RSpec.describe Dry::Files do
       expect(path).to have_content(expected)
     end
 
+    it "injects line at the bottom of the Ruby block (ignoring false positive blocks)" do
+      path = root.join("inject_line_at_block_bottom_gemfile.rb")
+      content = <<~CONTENT
+        group :development do
+          gem "hanami-webconsole"
+        end
+
+        group :development, :test do
+          gem "dotenv"
+        end
+
+        group :cli, :development do
+          gem "hanami-reloader"
+        end
+
+        group :cli, :development, :test do
+          gem "hanami-rspec"
+        end
+
+        group :test do
+          gem "rack-test"
+        end
+      CONTENT
+
+      subject.write(path, content)
+      subject.inject_line_at_block_bottom(path, "group :development do", %(gem "guard-puma"))
+
+      expected = <<~CONTENT
+        group :development do
+          gem "hanami-webconsole"
+          gem "guard-puma"
+        end
+
+        group :development, :test do
+          gem "dotenv"
+        end
+
+        group :cli, :development do
+          gem "hanami-reloader"
+        end
+
+        group :cli, :development, :test do
+          gem "hanami-rspec"
+        end
+
+        group :test do
+          gem "rack-test"
+        end
+      CONTENT
+
+      expect(path).to have_content(expected)
+    end
+
     it "injects line at the bottom of the Ruby block (using a Regexp matcher)" do
       path = root.join("inject_line_regexp_at_block_bottom.rb")
       content = <<~CONTENT


### PR DESCRIPTION
## The Problem

When generating a new Hanami app, the execution of the `bundle exec hanami install` command will cause the `hanami-reloader` gem to inject a line in the app's `Gemfile`.

`Dry::Files#inject_line_at_block_bottom` is aware of the opening/closing of a block, according to the `do` / `end` vs `{` and `}` styles.

The app's `Gemfile` uses the `do` / `end` style.
But `dry-files` gets confused when there is a string containing `"do"`, so the `gem "dotenv"` part triggered this bug.
It lets to think `Dry::Files#inject_line_at_block_bottom` that there is yet another block, but without the corresponding closing characters (`end`), it raises an exception.

## The Fix

I changed the matching logic from using `String` using just `"do"` to a `Regexp` that expects the closing block to be at the end of the line.