### PR TITLE
Enable JRuby support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,10 @@ jobs:
           - "3.4"
           - "3.3"
           - "3.2"
+          - "jruby"
         include:
           - ruby: "4.0"
             coverage: "true"
-          - ruby: "jruby"
-            optional: true
     env:
       COVERAGE: ${{ matrix.coverage }}
     steps:

--- a/repo-sync.yml
+++ b/repo-sync.yml
@@ -2,8 +2,6 @@ name:
   gem: dry-files
   constant: Dry::Files
 github_org: dry-rb
-ci:
-  jruby: false
 gemspec:
   authors: ["Hanakai team"]
   email: ["info@hanakai.org"]

--- a/spec/integration/dry/files_spec.rb
+++ b/spec/integration/dry/files_spec.rb
@@ -426,7 +426,7 @@ RSpec.describe Dry::Files do
         end
 
         with_ruby_engine(:jruby) do
-          expect(exception.cause).to be_kind_of(Errno::EPERM)
+          expect(exception.cause).to be_kind_of(Errno::EISDIR)
         end
 
         expect(exception.message).to include(path.to_s)

--- a/spec/unit/dry/files/file_system_spec.rb
+++ b/spec/unit/dry/files/file_system_spec.rb
@@ -491,7 +491,7 @@ RSpec.describe Dry::Files::FileSystem do
         end
 
         with_ruby_engine(:jruby) do
-          expect(exception.cause).to be_kind_of(Errno::EPERM)
+          expect(exception.cause).to be_kind_of(Errno::EISDIR)
         end
 
         expect(exception.message).to include(path.to_s)


### PR DESCRIPTION
We are now testing on JRuby 10.0.3.0, which has a fix for a bug that was causing Dry Files tests to not pass.