### PR TITLE
Implement Dry::Files#readlines method

### DIFF
--- a/lib/dry/files.rb
+++ b/lib/dry/files.rb
@@ -53,6 +53,20 @@ module Dry
       adapter.read(path)
     end
 
+    # Read file content into an array of lines
+    #
+    # @param path [String,Pathname] the path to file
+    #
+    # @return [Array] the lines of the file
+    #
+    # @raise [Dry::Files::IOError] in case of I/O error
+    #
+    # @since 1.2.0
+    # @api public
+    def readlines(path)
+      adapter.readlines(path)
+    end
+
     # Creates an empty file for the given path.
     # All the intermediate directories are created.
     # If the path already exists, it doesn't change the contents

--- a/spec/integration/dry/files_spec.rb
+++ b/spec/integration/dry/files_spec.rb
@@ -79,6 +79,36 @@ RSpec.describe Dry::Files do
     end
   end
 
+  describe "#readlines" do
+    it "reads file into an array" do
+      path = root.join("readlines")
+      subject.write(path, "Hello#{newline}World")
+
+      expect(subject.readlines(path)).to eq(["Hello#{newline}", "World"])
+    end
+
+    it "raises error when path is a directory" do
+      path = root.join("readlines-directory")
+      path.mkpath
+
+      expect { subject.readlines(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::EISDIR)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+
+    it "raises error when path doesn't exist" do
+      path = root.join("readlines-does-not-exist")
+
+      expect { subject.readlines(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Dry::Files::IOError)
+        expect(exception.cause).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to include(path.to_s)
+      end
+    end
+  end
+
   describe "#write" do
     it "creates an file with given contents" do
       path = root.join("write")


### PR DESCRIPTION
This method is mentioned in the documentation, but prior to this commit, calling it got a 'private method readlines called' error.  This private method turned out to be the readlines method from Ruby's Kernel module:

```
> Dry::Files.new.method(:readlines).owner
=> Kernel
```

This commit adds `readlines` as a public method of `Dry::Files`:

```
> Dry::Files.new.method(:readlines).owner
=> Dry::Files
```

Closes #20